### PR TITLE
Front-end Token Design

### DIFF
--- a/practice-app/requirements.txt
+++ b/practice-app/requirements.txt
@@ -11,3 +11,4 @@ PyJWT==2.3.0
 SQLAlchemy==1.4.36
 Werkzeug==2.1.2
 requests
+python-dotenv

--- a/practice-app/website/__init__.py
+++ b/practice-app/website/__init__.py
@@ -17,6 +17,7 @@ def create_app():
         os.path.join(basedir, DB_NAME)
     
     app.config["JWT_SECRET_KEY"] = "super-secret"  # Change this!
+    app.secret_key = "super-secret-2" # Change this! This is for flask session
     jwt = JWTManager(app)
 
     @jwt.user_identity_loader
@@ -35,12 +36,15 @@ def create_app():
     from .views import views
     from .api.event import event
     from .api.home import home
+    from .jwt import token
 
     app.register_blueprint(views, url_prefix="/")
     app.register_blueprint(home, url_prefix="/api")
     app.register_blueprint(event, url_prefix="/api")
+    app.register_blueprint(token, url_prefix="/token")
 
     from .api.auth import auth
+
     app.register_blueprint(auth, url_prefix="/api/")
 
     create_database(app)

--- a/practice-app/website/api/auth.py
+++ b/practice-app/website/api/auth.py
@@ -48,7 +48,7 @@ def login():
     if not user or not check_password_hash(user.password, password):
         return {'error': 'Incorrect email or password.'}, 401
 
-    is_artist = Artist.query.get(user.id)
+    artist = Artist.query.get(user.id)
 
-    access_token = create_access_token(identity=user, additional_claims={"user_id":user.id, "user_type": "artist" if is_artist else "user"})
+    access_token = create_access_token(identity=user, additional_claims={"user_id":user.id, "user_type": "artist" if artist else "user"})
     return jsonify(access_token=access_token)

--- a/practice-app/website/api/auth.py
+++ b/practice-app/website/api/auth.py
@@ -35,8 +35,8 @@ def signup():
         db.session.add(new_artist)
         db.session.commit()
 
-    access_token = create_access_token(additional_claims={"user_id":new_user.id, "user_type": "artist" if is_artist else "user"})
-    return jsonify(access_token=access_token, first_name=first_name), 201
+    access_token = create_access_token(identity=new_user, additional_claims={"user_id":new_user.id, "user_type": "artist" if is_artist else "user"})
+    return jsonify(access_token=access_token, is_artist=is_artist), 201
 
 
 @auth.route('/login', methods=['POST'])
@@ -51,4 +51,4 @@ def login():
     artist = Artist.query.get(user.id)
 
     access_token = create_access_token(identity=user, additional_claims={"user_id":user.id, "user_type": "artist" if artist else "user"})
-    return jsonify(access_token=access_token)
+    return jsonify(access_token=access_token, is_artist=artist!=None)

--- a/practice-app/website/api/jwt.py
+++ b/practice-app/website/api/jwt.py
@@ -1,0 +1,34 @@
+from functools import wraps
+from flask import jsonify
+from flask_jwt_extended import get_jwt, verify_jwt_in_request
+
+def artist_required():
+    def wrapper(fn):
+        @wraps(fn)
+        def decorator(*args, **kwargs):
+            verify_jwt_in_request()
+            claims = get_jwt()
+            print(claims)
+            if claims["user_type"] == "artist":
+                return fn(*args, **kwargs)
+            else:
+                return jsonify(msg="Only artists can view this page."), 403
+
+        return decorator
+
+    return wrapper
+
+def user_required():
+    def wrapper(fn):
+        @wraps(fn)
+        def decorator(*args, **kwargs):
+            verify_jwt_in_request()
+            claims = get_jwt()
+            if claims["user_type"] == "user":
+                return fn(*args, **kwargs)
+            else:
+                return jsonify(msg="Only users can view this page."), 403
+
+        return decorator
+
+    return wrapper

--- a/practice-app/website/jwt.py
+++ b/practice-app/website/jwt.py
@@ -1,11 +1,35 @@
 from functools import wraps
-from flask import request
+from flask import Blueprint, request, session
 from flask_jwt_extended import decode_token
+
+# Token Blueprint
+
+token = Blueprint("token", __name__)
+
+@token.route("/set", methods=["POST"])
+def set_session_token():
+    token = request.json["token"]
+    if token:
+        session["token"] = token
+        return {"success": "Token succesfully set."}, 200
+    else:
+        return {"success": "A token should be provided in the request body."}, 400
+
+@token.route("drop", methods=["POST"])
+def drop_session_token():
+    current_token = session["token"] 
+    if current_token:
+        session["token"] = None
+        return {"success": "Token removed from session."}, 200
+    else:
+        return {"error": "There is no token to remove from the session."}, 404
+
+# Decorators
 
 def artist_token_required(func):
     @wraps(func)
     def wrapped(*args, **kwargs):
-        token = request.args.get("token")
+        token = session["token"]
         if not token:
             return {"error": "You can not view this page without providing a valid token."}, 403
         try:
@@ -20,7 +44,7 @@ def artist_token_required(func):
 def user_token_required(func):
     @wraps(func)
     def wrapped(*args, **kwargs):
-        token = request.args.get("token")
+        token = session["token"]
         if not token:
             return {"error": "You can not view this page without providing a valid token."}, 403
         try:

--- a/practice-app/website/jwt.py
+++ b/practice-app/website/jwt.py
@@ -1,0 +1,33 @@
+from functools import wraps
+from flask import request
+from flask_jwt_extended import decode_token
+
+def artist_token_required(func):
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        token = request.args.get("token")
+        if not token:
+            return {"error": "You can not view this page without providing a valid token."}, 403
+        try:
+            claim = decode_token(token)
+            if claim["user_type"] != "artist":
+                return {"error": "Wrong user type."}, 403
+        except:
+            return {"error": "Invalid token."}, 403
+        return func(*args, **kwargs)
+    return wrapped
+
+def user_token_required(func):
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        token = request.args.get("token")
+        if not token:
+            return {"error": "You can not view this page without providing a valid token."}, 403
+        try:
+            claim = decode_token(token)
+            if claim["user_type"] != "user":
+                return {"error": "Wrong user type."}, 403
+        except:
+            return {"error": "Invalid token."}, 403
+        return func(*args, **kwargs)
+    return wrapped

--- a/practice-app/website/jwt.py
+++ b/practice-app/website/jwt.py
@@ -8,18 +8,23 @@ token = Blueprint("token", __name__)
 
 @token.route("/set", methods=["POST"])
 def set_session_token():
-    token = request.json["token"]
+
+    access_token = request.json["access_token"]
+    is_artist    = request.json["is_artist"]
+
     if token:
-        session["token"] = token
+        session["access_token"] = access_token
+        session["is_artist"]    = is_artist
         return {"success": "Token succesfully set."}, 200
     else:
         return {"success": "A token should be provided in the request body."}, 400
 
 @token.route("drop", methods=["POST"])
 def drop_session_token():
-    current_token = session["token"] 
+    current_token = session["access_token"] 
     if current_token:
-        session["token"] = None
+        session["access_token"] = None
+        session["is_artist"] = None
         return {"success": "Token removed from session."}, 200
     else:
         return {"error": "There is no token to remove from the session."}, 404

--- a/practice-app/website/models.py
+++ b/practice-app/website/models.py
@@ -19,6 +19,9 @@ class User(db.Model):
             "is_verified": self.is_verified
         }
 
+    def get_name(self):
+        return f"{self.first_name} {self.last_name}"
+
 
 class Artist(db.Model):
     id = db.Column(db.Integer, db.ForeignKey("user.id"), primary_key=True)
@@ -27,7 +30,7 @@ class Artist(db.Model):
     def serialize(self):
         return {
             "id": self.id,
-            "artisitic_values": self.artisitic_values
+            "artisitic_values": self.artistic_values
         }
 
 

--- a/practice-app/website/templates/base.html
+++ b/practice-app/website/templates/base.html
@@ -25,17 +25,39 @@
                 <input type="button" value="Search" onclick="search()">
             </form>
 
+            <div>
+                {% if session["token"] %}
+                    <form id="logoutForm">
+                        <input type="button" value="Logout" onclick="logout()">
+                    </form>
+                {% else %}
+                    <a href={{ url_for('views.login') }}>Login</a>
+                    <a href={{ url_for("views.signup") }}>Signup</a>
+                {% endif %}
+
+            </div>
+
+
             <script>
                 function search() {
                     var form = document.getElementById("searchBar");
                     var formData = new FormData(form)
-                    {% if token %}
-                    url = "/?token={{token}}&query=" + encodeURIComponent(formData.get("query"))
-                    {% else %}
                     url = "/?query=" + encodeURIComponent(formData.get("query"))
-                    {% endif %}
-                    
                     window.location.assign(url)
+                }
+
+                function logout() {
+                    var form = document.getElementById("logoutForm");
+                    var formData = new FormData(form)
+                    url = "/token/drop"
+                    fetch(url, {
+                        method: "POST",
+                        headers: {
+                            "Content-type": "application/json; charset=UTF-8"
+                        }
+                    }).then(() => {window.location.assign("/")})
+
+                    
                 }
             </script>
 
@@ -49,17 +71,12 @@
 
                 <div style="width: 15%; display: table-cell;">
                     
-                    {% if token %}
-
-                    <a href={{ url_for("views.home") }}?token={{token}}>Home</a>
-                    <a href={{ url_for("views.create_event") }}?token={{token}}>Create Event</a>
-                    <a href={{ url_for("views.home") }}>Logout</a>
-
-                    {% else %}
-
                     <a href={{ url_for("views.home") }}>Home</a>
-                    <a href={{ url_for('views.login') }}>Login</a>
-                    <a href={{ url_for("views.signup") }}>Signup</a>
+
+
+                    {% if session["token"] %}
+
+                    <a href={{ url_for("views.create_event") }}>Create Event</a>
                     
                     {% endif %}
                     

--- a/practice-app/website/templates/base.html
+++ b/practice-app/website/templates/base.html
@@ -26,7 +26,7 @@
             </form>
 
             <div>
-                {% if session["token"] %}
+                {% if session["access_token"] %}
                     <form id="logoutForm">
                         <input type="button" value="Logout" onclick="logout()">
                     </form>
@@ -73,8 +73,7 @@
                     
                     <a href={{ url_for("views.home") }}>Home</a>
 
-
-                    {% if session["token"] %}
+                    {% if session["is_artist"] %}
 
                     <a href={{ url_for("views.create_event") }}>Create Event</a>
                     

--- a/practice-app/website/templates/base.html
+++ b/practice-app/website/templates/base.html
@@ -29,7 +29,12 @@
                 function search() {
                     var form = document.getElementById("searchBar");
                     var formData = new FormData(form)
+                    {% if token %}
+                    url = "/?token={{token}}&query=" + encodeURIComponent(formData.get("query"))
+                    {% else %}
                     url = "/?query=" + encodeURIComponent(formData.get("query"))
+                    {% endif %}
+                    
                     window.location.assign(url)
                 }
             </script>
@@ -43,10 +48,22 @@
             <div style="display: table-row">
 
                 <div style="width: 15%; display: table-cell;">
+                    
+                    {% if token %}
+
+                    <a href={{ url_for("views.home") }}?token={{token}}>Home</a>
+                    <a href={{ url_for("views.create_event") }}?token={{token}}>Create Event</a>
+                    <a href={{ url_for("views.home") }}>Logout</a>
+
+                    {% else %}
+
                     <a href={{ url_for("views.home") }}>Home</a>
                     <a href={{ url_for('views.login') }}>Login</a>
                     <a href={{ url_for("views.signup") }}>Signup</a>
-                    <a href={{ url_for("views.create_event") }}>Create Event</a>
+                    
+                    {% endif %}
+                    
+                    
                 </div>
 
                 <div style="display: table-cell;"> 

--- a/practice-app/website/templates/create_event.html
+++ b/practice-app/website/templates/create_event.html
@@ -31,7 +31,7 @@
             body: JSON.stringify(Object.fromEntries(formData)),
             headers: {
                 "Content-type": "application/json; charset=UTF-8",
-                Authorization: "Bearer " + "{{token}}"
+                Authorization: "Bearer " + "{{session["token"]}}"
             }
         }).then(response => {
             if (response.status == 409) {
@@ -40,7 +40,7 @@
 
             if (response.status == 201) {
                 response.json().then(event_data => {
-                    window.location.assign('/event/' + event_data["id"] + "?token={{token}}")
+                    window.location.assign('/event/' + event_data["id"])
                 })
             }   
         })

--- a/practice-app/website/templates/create_event.html
+++ b/practice-app/website/templates/create_event.html
@@ -30,7 +30,8 @@
             method: "POST",
             body: JSON.stringify(Object.fromEntries(formData)),
             headers: {
-                "Content-type": "application/json; charset=UTF-8"
+                "Content-type": "application/json; charset=UTF-8",
+                Authorization: "Bearer " + "{{token}}"
             }
         }).then(response => {
             if (response.status == 409) {
@@ -39,7 +40,7 @@
 
             if (response.status == 201) {
                 response.json().then(event_data => {
-                    window.location.assign('/event/' + event_data["id"])
+                    window.location.assign('/event/' + event_data["id"] + "?token={{token}}")
                 })
             }   
         })

--- a/practice-app/website/templates/home.html
+++ b/practice-app/website/templates/home.html
@@ -20,12 +20,7 @@
     // IMPLEMENTING DIFFERENT FEATURES
 
     function display_event(event_data) {
-        {% if token %}
-            add_element("div", `<a href=/event/${event_data["id"]}?token={{token}}>${event_data["title"]}</a>`)
-        {% else %}
-            add_element("div", `<a href=/event/${event_data["id"]}>${event_data["title"]}</a>`)
-        {% endif %}
-        
+        add_element("div", `<a href=/event/${event_data["id"]}>${event_data["title"]}</a>`)
     }
 
     function display_art_item(art_item_data) {

--- a/practice-app/website/templates/home.html
+++ b/practice-app/website/templates/home.html
@@ -20,7 +20,12 @@
     // IMPLEMENTING DIFFERENT FEATURES
 
     function display_event(event_data) {
-        add_element("div", `<a href=/event/${event_data["id"]}>${event_data["title"]}</a>`)
+        {% if token %}
+            add_element("div", `<a href=/event/${event_data["id"]}?token={{token}}>${event_data["title"]}</a>`)
+        {% else %}
+            add_element("div", `<a href=/event/${event_data["id"]}>${event_data["title"]}</a>`)
+        {% endif %}
+        
     }
 
     function display_art_item(art_item_data) {

--- a/practice-app/website/templates/login.html
+++ b/practice-app/website/templates/login.html
@@ -40,7 +40,15 @@
             if (response.status == 200) {
                 response.json().then(userData => {
 
-                    location.href = '/?token=' + userData["access_token"];
+                    url = "/token/set"
+                    fetch(url, {
+                        method: "POST",
+                        body: JSON.stringify({"token":userData["access_token"]}),
+                        headers: {
+                            "Content-type": "application/json; charset=UTF-8"
+                        }
+                    }).then(() => {window.location.assign("/")})
+
                 })
             }
         })

--- a/practice-app/website/templates/login.html
+++ b/practice-app/website/templates/login.html
@@ -39,7 +39,8 @@
 
             if (response.status == 200) {
                 response.json().then(userData => {
-                    location.href = '/';
+
+                    location.href = '/?token=' + userData["access_token"];
                 })
             }
         })

--- a/practice-app/website/templates/login.html
+++ b/practice-app/website/templates/login.html
@@ -43,7 +43,7 @@
                     url = "/token/set"
                     fetch(url, {
                         method: "POST",
-                        body: JSON.stringify({"token":userData["access_token"]}),
+                        body: JSON.stringify(userData),
                         headers: {
                             "Content-type": "application/json; charset=UTF-8"
                         }

--- a/practice-app/website/templates/signup.html
+++ b/practice-app/website/templates/signup.html
@@ -42,7 +42,7 @@
                     url = "/token/set"
                     fetch(url, {
                         method: "POST",
-                        body: JSON.stringify({"token":userData["access_token"]}),
+                        body: JSON.stringify(userData),
                         headers: {
                             "Content-type": "application/json; charset=UTF-8"
                         }

--- a/practice-app/website/templates/signup.html
+++ b/practice-app/website/templates/signup.html
@@ -39,7 +39,7 @@
 
             if (response.status == 201) {
                 response.json().then(userData => {
-                    location.href = '/';
+                    location.href = '/?token=' + userData["access_token"];
                 })
             }
         })

--- a/practice-app/website/templates/signup.html
+++ b/practice-app/website/templates/signup.html
@@ -39,7 +39,14 @@
 
             if (response.status == 201) {
                 response.json().then(userData => {
-                    location.href = '/?token=' + userData["access_token"];
+                    url = "/token/set"
+                    fetch(url, {
+                        method: "POST",
+                        body: JSON.stringify({"token":userData["access_token"]}),
+                        headers: {
+                            "Content-type": "application/json; charset=UTF-8"
+                        }
+                    }).then(() => {window.location.assign("/")})
                 })
             }
         })

--- a/practice-app/website/templates/view_event.html
+++ b/practice-app/website/templates/view_event.html
@@ -38,7 +38,7 @@
                 add_element("div", "<img src=\"" + event_data["poster_link"] + "\">")
 
                 add_element("h2", "Artist")
-                add_element("div", event_data["creator_artist"])
+                add_element("div", event_data["artist_name"])
 
                 add_element("h2", "City & Date")
                 add_element("div", "<b>Date:</b>" + event_data["date"])

--- a/practice-app/website/views.py
+++ b/practice-app/website/views.py
@@ -7,20 +7,17 @@ views = Blueprint('views', __name__)
 
 @views.route("/")
 def home():
-    token = request.args.get("token")
-    return render_template("home.html", token=token)
+    return render_template("home.html")
 
 
 @views.route("event/<event_id>/")
 def view_event(event_id):
-    token = request.args.get("token")
-    return render_template("view_event.html", event_id=event_id, token=token)
+    return render_template("view_event.html", event_id=event_id)
 
 @views.route("create_event/")
 @artist_token_required
 def create_event():
-    token = request.args.get("token")
-    return render_template("create_event.html", token=token)
+    return render_template("create_event.html")
 
 
 @views.route('signup/')

--- a/practice-app/website/views.py
+++ b/practice-app/website/views.py
@@ -1,23 +1,26 @@
-from pickletools import read_unicodestring1
-from flask import Blueprint, render_template
-from flask_jwt_extended import jwt_required
+from flask import Blueprint, render_template, request
+
+from .jwt import artist_token_required, user_token_required
 
 views = Blueprint('views', __name__)
 
 
 @views.route("/")
 def home():
-    return render_template("home.html")
+    token = request.args.get("token")
+    return render_template("home.html", token=token)
 
 
 @views.route("event/<event_id>/")
 def view_event(event_id):
-    return render_template("view_event.html", event_id=event_id)
-
+    token = request.args.get("token")
+    return render_template("view_event.html", event_id=event_id, token=token)
 
 @views.route("create_event/")
+@artist_token_required
 def create_event():
-    return render_template("create_event.html")
+    token = request.args.get("token")
+    return render_template("create_event.html", token=token)
 
 
 @views.route('signup/')


### PR DESCRIPTION
In the current state, we are able to use the practice-app Rest API to signup and login. After these operations, we receive the tokens as response. We can't use these tokens in the front-end however. A solution needs to be found for this problem.

# New Design

Tokens will be stored in the URLs by extending the URL with `?token=<TOKEN>`.

For instance, when the user logs in, the front-end will receive the token from the back-end and redirect user to `/?token=<TOKEN>`.

New decorators will be written for the API and the front-end to reflect these changes.