### PR TITLE
Make unittests open a new db

### DIFF
--- a/practice-app/website/__init__.py
+++ b/practice-app/website/__init__.py
@@ -9,12 +9,12 @@ db = SQLAlchemy()
 DB_NAME = "database.db"
 
 
-def create_app():
+def create_app(db_name = DB_NAME):
     app = Flask(__name__)
 
     basedir = os.path.abspath(os.path.dirname(__file__))
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + \
-        os.path.join(basedir, DB_NAME)
+        os.path.join(basedir, db_name)
     
     app.config["JWT_SECRET_KEY"] = "super-secret"  # Change this!
     app.secret_key = "super-secret-2" # Change this! This is for flask session

--- a/practice-app/website/test/test_event.py
+++ b/practice-app/website/test/test_event.py
@@ -5,11 +5,13 @@ from ..models import Event
 
 from ..api.event import title_exists, date_valid
 
+TEST_DB_NAME = "test_database.db"
+
 class TestEvent(unittest.TestCase):
 
     def setUp(self):
 
-        app = create_app()
+        app = create_app(TEST_DB_NAME)
         self.ctx = app.app_context()
         self.ctx.push()
         self.client = app.test_client()

--- a/practice-app/website/test/test_home.py
+++ b/practice-app/website/test/test_home.py
@@ -4,11 +4,13 @@ from .. import create_app, db
 
 from ..api.home import *
 
+TEST_DB_NAME = "test_database.db"
+
 class TestHome(unittest.TestCase):
 
     def setUp(self):
         
-        app = create_app()
+        app = create_app(TEST_DB_NAME)
         self.ctx = app.app_context()
         self.ctx.push()
         self.client = app.test_client()


### PR DESCRIPTION
With this merge, I am making the unittests use a database other than the original database.

Currently, unittests connect to the original database. This causes problems since state of the original database changes with time as people use it. This is not desirable for unittests.

Solution I am requesting to pull will make the unittests open a new database and operate on it. 

# Testing

I have run our application and added and created an event. Then I ran the unittests. After the unittests were succesful, I ran the application again and the event I created before running the tests was still available.