### PR TITLE
Add authentication (FE)

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,7 +1,11 @@
 # add git-ignore syntax here of things you don't want copied into docker image
 
 .git
+.gitignore
+READme.md
 *Dockerfile*
 *docker-compose*
-node_modules
 .parcel-cache
+dist
+node_modules
+package-lock.json

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,41 +5,47 @@ import {
   RouterProvider,
 } from "react-router-dom";
 
+import { Routes, Route } from "react-router-dom";
+
 import ResponsiveAppBar from './ResponsiveAppBar';
 import HomePage from "./pages/HomePage/HomePage"
+import CreateArtItemPage from "./pages/ArtItemPage/CreateArtItemPage"
 import ArtItemPage from "./pages/ArtItemPage/ArtItemPage"
 import SignInPage from './pages/Authentication/SignInPage';
 import SignUpPage from './pages/Authentication/SignUpPage';
 
-import Container from '@mui/material/Container';
+import { AuthProvider } from './auth/useAuth';
+import {ProtectedRoute} from './auth/ProtectedRoute';
 
-const router = createBrowserRouter([
-  {
-    path: "/",
-    element: <HomePage />,
-  },
-  {
-    path: "/auth/signup",
-    element: <SignUpPage />
-  },
-  {
-    path: "/auth/signin",
-    element: <SignInPage />
-  },
-  {
-    // dynamic routing: id parameter can be accessed
-    // in ArtItemPage. See ArtItemPage code to learn
-    // how.
-    path: "/art_item/:id",
-    element: <ArtItemPage />
-  }
-]);
 
 function App() {
   return (
     <div>
-      <ResponsiveAppBar />
-      <RouterProvider router={router} />
+      <AuthProvider>
+        <ResponsiveAppBar />
+        <Routes>
+          <Route
+            path="/"
+            element={<HomePage />}
+          />
+          <Route
+            path="/auth/signup"
+            element={<SignUpPage />}
+          />
+          <Route
+            path="/auth/signin"
+            element={<SignInPage />}
+          />
+          <Route
+            path="/art_item/:id"
+            element={<ArtItemPage />}
+          />
+          <Route
+            path="/new/art_item"
+            element={<ProtectedRoute><CreateArtItemPage /></ProtectedRoute>} 
+          />
+        </Routes>
+      </AuthProvider>
     </div>
   );
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,9 +1,5 @@
 
 import React from 'react'
-import {
-  createBrowserRouter,
-  RouterProvider,
-} from "react-router-dom";
 
 import { Routes, Route } from "react-router-dom";
 
@@ -13,6 +9,7 @@ import CreateArtItemPage from "./pages/ArtItemPage/CreateArtItemPage"
 import ArtItemPage from "./pages/ArtItemPage/ArtItemPage"
 import SignInPage from './pages/Authentication/SignInPage';
 import SignUpPage from './pages/Authentication/SignUpPage';
+import ErrorPage from './pages/ErrorPage';
 
 import { AuthProvider } from './auth/useAuth';
 import {ProtectedRoute} from './auth/ProtectedRoute';
@@ -44,6 +41,7 @@ function App() {
             path="/new/art_item"
             element={<ProtectedRoute><CreateArtItemPage /></ProtectedRoute>} 
           />
+          <Route path="*" element={<ErrorPage />} />
         </Routes>
       </AuthProvider>
     </div>

--- a/frontend/src/ResponsiveAppBar.js
+++ b/frontend/src/ResponsiveAppBar.js
@@ -14,8 +14,9 @@ import Tooltip from '@mui/material/Tooltip';
 import MenuItem from '@mui/material/MenuItem';
 import AdbIcon from '@mui/icons-material/Adb';
 
-const pages = ['Events', 'Art Items', 'Discussion Forum'];
-const settings = ['Profile', 'Account', 'Logout'];
+
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from "./auth/useAuth";
 
 const ResponsiveAppBar = () => {
     const [anchorElNav, setAnchorElNav] = React.useState(null);
@@ -35,6 +36,33 @@ const ResponsiveAppBar = () => {
     const handleCloseUserMenu = () => {
         setAnchorElUser(null);
     };
+
+    const pages = ['Events', 'Art Items', 'Discussion Forum'];
+
+    const navigate = useNavigate()
+    const { token, clearToken } = useAuth()
+
+    let settings = token ? [
+        {
+            "name": "Log Out",
+            "onClick": () => {
+                clearToken()
+            }
+        }
+    ] : [
+        {
+            "name": "Sign Up",
+            "onClick": () => {
+                navigate("/auth/signup")
+            }
+        },
+        { // if no token add
+            "name": "Sign In",
+            "onClick": () => {
+                navigate("/auth/signin")
+            }
+        }
+    ]
 
     return (
         <AppBar position="static">
@@ -149,8 +177,8 @@ const ResponsiveAppBar = () => {
                             onClose={handleCloseUserMenu}
                         >
                             {settings.map((setting) => (
-                                <MenuItem key={setting} onClick={handleCloseUserMenu}>
-                                    <Typography textAlign="center">{setting}</Typography>
+                                <MenuItem key={setting.name} onClick={() => {setting.onClick(); handleCloseUserMenu()}}>
+                                    <Typography textAlign="center">{setting.name}</Typography>
                                 </MenuItem>
                             ))}
                         </Menu>

--- a/frontend/src/auth/ProtectedRoute.js
+++ b/frontend/src/auth/ProtectedRoute.js
@@ -1,0 +1,12 @@
+import React from "react";
+import { Navigate } from "react-router-dom";
+import { useAuth } from "./useAuth";
+
+export const ProtectedRoute = ({ children }) => {
+  const { token } = useAuth();
+  if (!token) {
+    // user is not authenticated
+    return <Navigate to="/" />;
+  }
+  return children;
+};

--- a/frontend/src/auth/useAuth.js
+++ b/frontend/src/auth/useAuth.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { createContext, useContext, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { useLocalStorage } from "./useLocalStorage";
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [token, setToken] = useLocalStorage("token", null);
+  const navigate = useNavigate();
+
+  // call this function when you want to authenticate the user
+  const saveToken = (token) => {
+    setToken(token);
+    navigate("/");
+  };
+
+  // call this function to sign out logged in user
+  const clearToken = () => {
+    setToken(null);
+    navigate("/", { replace: true });
+  };
+
+  const value = useMemo(
+    () => ({
+      token,
+      saveToken,
+      clearToken
+    }),
+    [token]
+  );
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  return useContext(AuthContext);
+};

--- a/frontend/src/auth/useLocalStorage.js
+++ b/frontend/src/auth/useLocalStorage.js
@@ -1,0 +1,24 @@
+import { useState } from "react";
+
+export const useLocalStorage = (keyName, defaultValue) => {
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      const value = window.localStorage.getItem(keyName);
+      if (value) {
+        return JSON.parse(value);
+      } else {
+        window.localStorage.setItem(keyName, JSON.stringify(defaultValue));
+        return defaultValue;
+      }
+    } catch (err) {
+      return defaultValue;
+    }
+  });
+  const setValue = (newValue) => {
+    try {
+      window.localStorage.setItem(keyName, JSON.stringify(newValue));
+    } catch (err) {}
+    setStoredValue(newValue);
+  };
+  return [storedValue, setValue];
+};

--- a/frontend/src/common/CommentSection.js
+++ b/frontend/src/common/CommentSection.js
@@ -6,10 +6,12 @@ import Typography from '@mui/material/Typography';
 import UserCard from './UserCard'
 import NewComment from './NewComment'
 
+import {useAuth} from "../auth/useAuth"
+
 function CommentSection(props) {
   
   let commentComponents = props.comments.map(commentData => UserCard(commentData))
-
+  const {token} = useAuth() 
   return (
     <Box sx={{
       width: '90%',
@@ -24,7 +26,8 @@ function CommentSection(props) {
 
       <Stack spacing={2}>
         {commentComponents}
-        <NewComment />
+        {token && <NewComment />}
+        
       </Stack>
     </Box>
   );

--- a/frontend/src/common/UserCard.js
+++ b/frontend/src/common/UserCard.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import {useNavigate} from 'react-router-dom';
+import { useAuth } from "../auth/useAuth";
 
 import { CardHeader, CardContent, Card, Avatar, IconButton, Typography, MenuItem, Menu } from '@mui/material';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
@@ -12,7 +13,7 @@ function UserCard(props) {
 
   let { userData, body, date } = props
 
-  const logged_in_user = true // TODO: set to true only if there is a JWT token
+  const { token } = useAuth()
 
   // HANDLING FOLLOW/LIKE FUNCTIONALITIES
 
@@ -91,7 +92,7 @@ function UserCard(props) {
           </CardContent>
         }
 
-        {logged_in_user && // if logged_in_user, render below 
+        {token && // if logged_in_user, render below 
           <CardActions disableSpacing>
             <IconButton onClick={body ? handleCommentLike : handleUserFollow} aria-label="add to favorites">
               {starState.stared ? <StarIcon /> : <StarOutlineIcon />}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,12 +1,13 @@
 
 import React from 'react'
 import ReactDOM from 'react-dom';
+import { BrowserRouter } from "react-router-dom";
 
 import App from './App'
 
 ReactDOM.render(
-    <React.StrictMode>
+    <BrowserRouter>
         <App />
-    </React.StrictMode>,
+    </BrowserRouter>,
     document.getElementById('root')
 );

--- a/frontend/src/pages/ArtItemPage/CreateArtItemPage.js
+++ b/frontend/src/pages/ArtItemPage/CreateArtItemPage.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+function CreateArtItemPage() {
+    return (
+        <div>
+            This page is protected
+        </div>
+    )
+}
+
+export default CreateArtItemPage

--- a/frontend/src/pages/Authentication/SignInPage.js
+++ b/frontend/src/pages/Authentication/SignInPage.js
@@ -1,5 +1,6 @@
 import React, { useReducer } from "react";
 import {useNavigate} from 'react-router-dom';
+import { useAuth } from "../../auth/useAuth";
 
 import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
@@ -21,14 +22,16 @@ function SignInForm(props) {
   // otherwise breaks the 'Rules of Hooks' apparently.
   // ref: https://stackoverflow.com/questions/60700905/react-native-navigate-to-screen-invalid-hook-call
   const navigate = useNavigate();
+  const { saveToken } = useAuth()
 
   // Called when the user clicks the submit button. Observe how
   // the handleSubmit button is attached to the 'form' component
   // below in the return call of SignUpForm function.
   const handleSubmit = event => {
     event.preventDefault();
-
-    let data = { formInput };
+    
+    console.log(formInput)
+    saveToken(formInput.email)
 
     /*
     // Here is how we will make a POST request in the backend.

--- a/frontend/src/pages/Authentication/SignInPage.js
+++ b/frontend/src/pages/Authentication/SignInPage.js
@@ -29,8 +29,6 @@ function SignInForm(props) {
   // below in the return call of SignUpForm function.
   const handleSubmit = event => {
     event.preventDefault();
-    
-    console.log(formInput)
     saveToken(formInput.email)
 
     /*

--- a/frontend/src/pages/ErrorPage.js
+++ b/frontend/src/pages/ErrorPage.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Link } from 'react-router-dom';
+
+export default function ErrorPage() {
+
+  return (
+    <div style={{textAlign:"center"}}>
+      <h1>Oops!</h1>
+      <p>Sorry, an unexpected error has occurred.</p>
+      <p>
+        <Link to="/">Go to Home </Link>
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
I have completed implementation of the authentication & token handling.

## Sign-in / Log-out

- If you click the profile avatar to the right of the navigation bar in any page, you will see options to sign-in/sign-up or log-out:

![image](https://user-images.githubusercontent.com/57228345/197708903-11828d98-a4c3-468b-9669-15590ecbf6de.png)

![image](https://user-images.githubusercontent.com/57228345/197708950-2ee715e5-72e9-4516-aaec-c5b62e914c5e.png)

Menu items are all functional and work as you would expect. If you go to sign in and enter e-mail and password (any e-mail & password until backend gives us an endpoint), you will be directed to the home page. When you click on the menu now, you will be able to log-out. If you log-out, you will be in the same state you were in before logging in.

## Protected Pages

You can now protect pages like the create art item page by using the `ProtectedRoute` component:
```js
<Route
  path="/new/art_item"
  element={<ProtectedRoute><CreateArtItemPage /></ProtectedRoute>} 
/>
```

## Updating Components

Now that we can check whether a token exists, I have updated some components.

### Navigation Bar

Change is as explained in the Sign-in / Log-out section I wrote above.

### User Cards

Follow user button is hidden.

![image](https://user-images.githubusercontent.com/57228345/197710056-0b83eb0f-d375-4415-b13a-e883199b503e.png)

### Comments Section

Like comment buttons and write new comment sections are hidden.

![image](https://user-images.githubusercontent.com/57228345/197709959-a095f4be-97ce-44eb-8baf-47907f5385ef.png)




