### PR TITLE
Dev/frontend/art item integration

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -34,7 +34,7 @@ function App() {
             element={<SignInPage />}
           />
           <Route
-            path="/art_item/:id"
+            path="/artitem/:id"
             element={<ArtItemPage />}
           />
           <Route

--- a/frontend/src/common/CommentSection.js
+++ b/frontend/src/common/CommentSection.js
@@ -10,7 +10,7 @@ import {useAuth} from "../auth/useAuth"
 
 function CommentSection(props) {
   
-  let commentComponents = props.comments.map(commentData => UserCard(commentData))
+  let commentComponents = props.commentList.map(commentData => UserCard(commentData))
   const {token} = useAuth() 
   return (
     <Box sx={{

--- a/frontend/src/common/UserCard.js
+++ b/frontend/src/common/UserCard.js
@@ -11,7 +11,7 @@ import StarOutlineIcon from '@mui/icons-material/StarOutline';
 
 function UserCard(props) {
 
-  let { userData, body, date } = props
+  const { author, body, createdAt } = props
 
   const { token } = useAuth()
 
@@ -40,6 +40,8 @@ function UserCard(props) {
 
   const navigate = useNavigate()
 
+  console.log(author)
+
   // RENDER
 
   return (
@@ -51,11 +53,11 @@ function UserCard(props) {
         <CardHeader 
           avatar = {
             <Avatar sx={{ bgcolor: 'secondary.main' }} aria-label="user">
-              {userData.level}
+              {author.level}
             </Avatar>
           }
-          title={userData.name}
-          subheader={date}
+          title={author.accountInfo.name + " " + author.accountInfo.surname}
+          subheader={createdAt}
           action={
             <IconButton onClick={handleOpenUserMenu} aria-label="settings">
               <MoreVertIcon />
@@ -79,7 +81,7 @@ function UserCard(props) {
           open={Boolean(anchorElUser)}
           onClose={handleCloseUserMenu}
         >
-          <MenuItem key='See Profile' onClick={() => {navigate("/user/" + userData.user_id)}}>
+          <MenuItem key='See Profile' onClick={() => {navigate("/user/" + author.user_id)}}>
             <Typography textAlign="center">See Profile</Typography>
           </MenuItem>          
         </Menu>

--- a/frontend/src/pages/ArtItemPage/ArtItemPage.js
+++ b/frontend/src/pages/ArtItemPage/ArtItemPage.js
@@ -18,12 +18,14 @@ function ArtItemPage() {
   })
 
   const { token } = useAuth()
-  const fetchArgs = {
-    method: "GET",  
-  }
-  if (token) fetchArgs.headers = {Authorization: "Bearer " + token}
   
   useEffect(() => {
+
+    const fetchArgs = {
+      method: "GET",  
+    }
+
+    if (token) fetchArgs.headers = {Authorization: "Bearer " + token}
     fetch('/art_item/' + id, fetchArgs)
       .then((response) => response.json())
       .then((data) => {
@@ -34,7 +36,7 @@ function ArtItemPage() {
           setState({error: error})
         }
       )
-  }, [])
+  }, [id, token])
 
   const {error, isLoaded, artitem} = state
 
@@ -52,7 +54,7 @@ function ArtItemPage() {
     
       <Grid container>
         <Grid item xs={6} sx={{padding:2}}>
-          <img src={artitem.artItemInfo.imageUrl} style={{width:'100%'}}/>
+          <img src={artitem.artItemInfo.imageUrl} alt="Art Item" style={{width:'100%'}}/>
         </ Grid>
         <Grid item xs={6} sx={{padding:2}}>
           <Typography variant="h5">Owner:</Typography>

--- a/frontend/src/pages/ArtItemPage/ArtItemPage.js
+++ b/frontend/src/pages/ArtItemPage/ArtItemPage.js
@@ -1,125 +1,108 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import {useParams} from "react-router-dom";
 
 import CommentSection from "../../common/CommentSection"
 import UserCard from "../../common/UserCard"
+import { useAuth } from "../../auth/useAuth"
 
 import { Typography, Grid } from '@mui/material';
 
-function fetchArtItemData(id) {
-  // we will replace the mock data below with
-  // and api call once the api endpoint is
-  // ready in the backend.
-
-  const data = {
-    "art_item_title": "Super Art Item",
-    "description": "Super Description",
-    "auction_id": 2,
-    "image": "https://picsum.photos/200/300",
-    "artist": {
-      "level": 6,
-      "name": "Mehmet",
-      "user_id": 1
-    },
-    "collaborators": [
-      {
-        "level": 7,
-        "name": "Husnu",
-        "user_id": 2
-      },
-      {
-        "level": 4,
-        "name": "Hasan",
-        "user_id": 3
-      },
-    ],
-    "related_events": [
-      {
-        "title": "Super Event",
-        "id": 2
-      }
-    ],
-    "comments": [
-      {
-        "userData": {
-          "level": 6,
-          "name": "Picasso",
-          "user_id": 4,
-        },
-        "body": "Super Comment",
-        "date": "Super date"
-      },
-      {
-        "userData": {
-          "level": 4,
-          "name": "Da Vinci",
-          "user_id": 6,
-        },
-        "body": "Super Comment 2",
-        "date": "Super date 2"
-      }
-    ],
-    "labels": "?"
-  }
-  return data
-}
-
 function ArtItemPage() {
-    
   let { id } = useParams();
 
-  const data = fetchArtItemData(id)
+  const [error, setError] = React.useState(null)
+  const [isLoaded, setLoaded] = React.useState(false)
+  const [artData, setData] = React.useState([])
 
-  return (
-    <div>
-      <Typography variant="h4" sx={{padding:2}}>
-        {data.art_item_title}
-      </Typography>
-    
-      <Grid container>
-        <Grid item xs={6} sx={{padding:2}}>
-          <img src={data.image} style={{width:'100%'}}/>
-        </ Grid>
-        <Grid item xs={6} sx={{padding:2}}>
-          <Typography variant="h5">Artist:</Typography>
-          <UserCard userData={data.artist}/>
+  const { token } = useAuth()
+  const fetchHeaders = {
+      Authorization: 'Bearer ' + token
+  }
 
-          {data.collaborators && // if collaborators exists, render block below
-            <div>
-              <Typography variant="h5">Collaborators:</Typography>
-              {data.collaborators.map(collaboratorData => <UserCard userData={collaboratorData} />)            }
-            </div>
-          }
-          
-          <Typography variant="h5">Description:</Typography>
-          <Typography variant="body1">{data.description}</Typography>
+  useEffect(() => {
+    const promise = fetch('/art_item/' + id, {
+        headers: fetchHeaders,
+        method: 'GET',
+    })
+        .then((response) => response.json())
+        .then((data) => {
+            setLoaded(true)
+            console.log(data)
+            console.log(artData)
+            setData(data)
+            console.log(artData)
+        },
+            error => {
+                console.log(error)
+                setLoaded(true)
+                setError(error)
+            })
 
-          { data.related_events && // if related_events is provided in data, render the block below
-          // TODO: render event properly.
-            <div>
-              <Typography variant="h5">Related Events:</Typography>
-              {data.related_events.map(eventData => eventData.title + ", ")}
-            </div>
-          }
+    return () => {
+        promise.cancel()
+    }
+  }, [])
 
-          { data.auction_id && // if auction_id exists, render block below
-          // TODO render auction properly
-            <div>
-              <Typography variant="h5">Auction:</Typography>
-              Auction at id={data.auction_id}
-            </div>
-          }
+  if (error) {
+    return <div>Error: {error.message}</div>
+  } else if (!isLoaded) {
+    return <div>Loading...</div>
+  } else {
+    console.log(artData)
+    return (
+      <div>
+        <Typography variant="h4" sx={{padding:2}}>
+          {artData.artItemInfo.name}
+        </Typography>
+      
+        <Grid container>
+          <Grid item xs={6} sx={{padding:2}}>
+            <img src={artData.artItemInfo.imageUrl} style={{width:'100%'}}/>
+          </ Grid>
+          <Grid item xs={6} sx={{padding:2}}>
+            <Typography variant="h5">Artist:</Typography>
+            <UserCard userData={{level: 1, name: "not_provided", user_id: artData.creator.id}}/>
+
+            {/*
+              artData.collaborators && // if collaborators exists, render block below
+              <div>
+                <Typography variant="h5">Collaborators:</Typography>
+                {artData.collaborators.map(collaboratorData => <UserCard userData={collaboratorData} />)            }
+              </div>
+              */
+            }
+            
+            <Typography variant="h5">Description:</Typography>
+            <Typography variant="body1">{artData.description}</Typography>
+
+            {/* artData.related_events && // if related_events is provided in data, render the block below
+            // TODO: render event properly.
+              <div>
+                <Typography variant="h5">Related Events:</Typography>
+                {artData.related_events.map(eventData => eventData.title + ", ")}
+              </div>
+            */}
+
+            {/* artData.auction_id && // if auction_id exists, render block below
+            // TODO render auction properly
+              <div>
+                <Typography variant="h5">Auction:</Typography>
+                Auction at id={artData.auction_id}
+              </div>
+            */}
 
 
-        </ Grid>
-        <CommentSection
-          id={id}
-          comments={data.comments}
-        />
-      </ Grid>  
-    </div>
-    
-  )
+          </ Grid>
+          {/*
+          <CommentSection
+            id={id}
+            comments={artData.comments}
+          />*/}
+        </ Grid>  
+      </div>
+      
+    )
+  }
 }
 
 

--- a/frontend/src/pages/ArtItemPage/ArtItemPage.js
+++ b/frontend/src/pages/ArtItemPage/ArtItemPage.js
@@ -1,108 +1,84 @@
-import React, { useEffect } from 'react'
+import React, {useEffect, useState} from 'react'
 import {useParams} from "react-router-dom";
+import { useAuth } from "../../auth/useAuth"
 
 import CommentSection from "../../common/CommentSection"
 import UserCard from "../../common/UserCard"
-import { useAuth } from "../../auth/useAuth"
 
 import { Typography, Grid } from '@mui/material';
 
 function ArtItemPage() {
+  
   let { id } = useParams();
 
-  const [error, setError] = React.useState(null)
-  const [isLoaded, setLoaded] = React.useState(false)
-  const [artData, setData] = React.useState([])
+  const [state, setState] = useState({
+    error: null,
+    isLoaded: false,
+    artitem: [] 
+  })
 
   const { token } = useAuth()
-  const fetchHeaders = {
-      Authorization: 'Bearer ' + token
+  const fetchArgs = {
+    method: "GET",  
   }
-
+  if (token) fetchArgs.headers = {Authorization: "Bearer " + token}
+  
   useEffect(() => {
-    const promise = fetch('/art_item/' + id, {
-        headers: fetchHeaders,
-        method: 'GET',
-    })
-        .then((response) => response.json())
-        .then((data) => {
-            setLoaded(true)
-            console.log(data)
-            console.log(artData)
-            setData(data)
-            console.log(artData)
-        },
-            error => {
-                console.log(error)
-                setLoaded(true)
-                setError(error)
-            })
-
-    return () => {
-        promise.cancel()
-    }
+    fetch('/art_item/' + id, fetchArgs)
+      .then((response) => response.json())
+      .then((data) => {
+        console.log(data)
+        setState({error: null, isLoaded: true, artitem: data})
+      },
+        error => {
+          setState({error: error})
+        }
+      )
   }, [])
+
+  const {error, isLoaded, artitem} = state
 
   if (error) {
     return <div>Error: {error.message}</div>
   } else if (!isLoaded) {
     return <div>Loading...</div>
   } else {
-    console.log(artData)
-    return (
-      <div>
-        <Typography variant="h4" sx={{padding:2}}>
-          {artData.artItemInfo.name}
-        </Typography>
-      
-        <Grid container>
-          <Grid item xs={6} sx={{padding:2}}>
-            <img src={artData.artItemInfo.imageUrl} style={{width:'100%'}}/>
-          </ Grid>
-          <Grid item xs={6} sx={{padding:2}}>
-            <Typography variant="h5">Artist:</Typography>
-            <UserCard userData={{level: 1, name: "not_provided", user_id: artData.creator.id}}/>
+    console.log(artitem)
+  return (
+    <div>
+      <Typography variant="h4" sx={{padding:2}}>
+        {artitem.artItemInfo.name}
+      </Typography>
+    
+      <Grid container>
+        <Grid item xs={6} sx={{padding:2}}>
+          <img src={artitem.artItemInfo.imageUrl} style={{width:'100%'}}/>
+        </ Grid>
+        <Grid item xs={6} sx={{padding:2}}>
+          <Typography variant="h5">Owner:</Typography>
+          <UserCard author={artitem.owner}/>
+          
+          <Typography variant="h5">Description:</Typography>
+          <Typography variant="body1">{artitem.artItemInfo.description}</Typography>
 
-            {/*
-              artData.collaborators && // if collaborators exists, render block below
-              <div>
-                <Typography variant="h5">Collaborators:</Typography>
-                {artData.collaborators.map(collaboratorData => <UserCard userData={collaboratorData} />)            }
-              </div>
-              */
-            }
-            
-            <Typography variant="h5">Description:</Typography>
-            <Typography variant="body1">{artData.description}</Typography>
-
-            {/* artData.related_events && // if related_events is provided in data, render the block below
-            // TODO: render event properly.
-              <div>
-                <Typography variant="h5">Related Events:</Typography>
-                {artData.related_events.map(eventData => eventData.title + ", ")}
-              </div>
-            */}
-
-            {/* artData.auction_id && // if auction_id exists, render block below
-            // TODO render auction properly
-              <div>
-                <Typography variant="h5">Auction:</Typography>
-                Auction at id={artData.auction_id}
-              </div>
-            */}
+          {artitem.onAuction && // if auction_id exists, render block below
+          // TODO render auction properly
+            <div>
+              <Typography variant="h5">Auction Price:</Typography>
+              Auction at id={artitem.lastPrice}
+            </div>
+          }
 
 
-          </ Grid>
-          {/*
-          <CommentSection
-            id={id}
-            comments={artData.comments}
-          />*/}
-        </ Grid>  
-      </div>
-      
-    )
-  }
+        </ Grid>
+        <CommentSection
+          id={id}
+          commentList={artitem.commentList.filter(x => !!x.author)}
+        />
+      </ Grid>  
+    </div>
+    
+  )}
 }
 
 

--- a/frontend/src/pages/HomePage/HomePage.js
+++ b/frontend/src/pages/HomePage/HomePage.js
@@ -63,7 +63,7 @@ const HomePage = () => {
                 <Grid container item xs={12} md={4} direction='column' wrap='wrap'>
                     {artitems.map(artitem => (
                         <Grid key={artitem.id} item>
-                            <Link href={"/art_item/" + artitem.id} underline="none">
+                            <Link href={"/artitem/" + artitem.id} underline="none">
                                 <ArtItem data={artitem} />
                             </Link>
                         </Grid>


### PR DESCRIPTION
With this PR, I want the merge the integration of art item page with the backend endpoint. I have done the following changes:
- I have replaced the mock data in art item page with a request to the endpoint
- I have updated art item page and other components according to the field names of the endpoint response.
- I have renamed the `/art_item/:id` route as `/artitem/:id` in the frontend to avoid using the same route as backend.

Now, the user can click an art item in the home page and navigate to its page:

![image](https://user-images.githubusercontent.com/57228345/198933236-6d79ff46-f10c-4aab-a45e-d10accc14ada.png)

![image](https://user-images.githubusercontent.com/57228345/198933299-f71d8d0c-4ef2-4ebf-bcd6-f615329c925d.png)

The art item page can also render auctions if the `onAuction` field of the response is true.