### PR TITLE
Merge app name updates into develop

### DIFF
--- a/android/android/app/src/main/AndroidManifest.xml
+++ b/android/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.group7.artshare.android">
    <application
-        android:label="ArtShare"
+        android:label="ideart"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/lib/main.dart
+++ b/android/lib/main.dart
@@ -26,7 +26,7 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => LoginProvider()),
       ],
       child: MaterialApp(
-        title: 'ArtShare',
+        title: 'ideart',
         theme: ThemeData(
           primarySwatch: Colors.blue,
         ),

--- a/android/lib/pages/home_page.dart
+++ b/android/lib/pages/home_page.dart
@@ -36,12 +36,13 @@ class _HomePageState extends State<HomePage> {
         SliverAppBar(
           backgroundColor: Colors.blue[300],
           title: const Text(
-            'Art Share',
+            'ideart.',
             style: TextStyle(
               color: Colors.white,
+              fontFamily: 'monospace',
               fontSize: 24.0,
               fontWeight: FontWeight.bold,
-              letterSpacing: 0,
+              letterSpacing: 0.2,
             ),
           ),
           centerTitle: false,
@@ -108,11 +109,13 @@ class _HomePageState extends State<HomePage> {
               ),
               child: Stack(
                 alignment: Alignment.bottomLeft,
-                children: [
+                children: const [
                   Text(
-                    "Art Community",
+                    "ideart.",
                     style: TextStyle(
                         color: Colors.white,
+                        fontFamily: 'monospace',
+                        letterSpacing: 0.2,
                         fontSize: 20,
                         fontWeight: FontWeight.bold),
                   ),

--- a/android/lib/widgets/form_app_bar.dart
+++ b/android/lib/widgets/form_app_bar.dart
@@ -11,7 +11,16 @@ class _FormAppBarState extends State<FormAppBar> {
   @override
   Widget build(BuildContext context) {
     return AppBar(
-      title: const Text("ArtShare"),
+      title: const Text(
+            'ideart.',
+            style: TextStyle(
+              color: Colors.white,
+              fontFamily: 'monospace',
+              fontSize: 24.0,
+              fontWeight: FontWeight.bold,
+              letterSpacing: 0.2,
+            ),
+          ),
       elevation: 0.1,
     );
   }

--- a/android/lib/widgets/logo.dart
+++ b/android/lib/widgets/logo.dart
@@ -13,13 +13,15 @@ class Logo extends StatelessWidget {
           size: 150,
         ),
         // App Name
-        Text(
-          'Art Share',
-          style: TextStyle(
-            fontSize: 50,
-            fontWeight: FontWeight.bold,
-            color: Colors.white,
-          ),
+        const Text(
+            'ideart.',
+            style: TextStyle(
+              color: Colors.white,
+              fontFamily: 'monospace',
+              fontSize: 50.0,
+              fontWeight: FontWeight.bold,
+              letterSpacing: 0.2,
+            ),
         ),
       ],
     );

--- a/frontend/src/ResponsiveAppBar.js
+++ b/frontend/src/ResponsiveAppBar.js
@@ -37,7 +37,7 @@ const ResponsiveAppBar = () => {
         setAnchorElUser(null);
     };
 
-    const pages = ['Events', 'Art Items', 'Discussion Forum'];
+    const pages = ['Discussion Forum', 'Events', 'Auctions'];
 
     const navigate = useNavigate()
     const { token, clearToken } = useAuth()
@@ -79,12 +79,12 @@ const ResponsiveAppBar = () => {
                             display: { xs: 'none', md: 'flex' },
                             fontFamily: 'monospace',
                             fontWeight: 700,
-                            letterSpacing: '.3rem',
+                            letterSpacing: '.2rem',
                             color: 'inherit',
                             textDecoration: 'none',
                         }}
                     >
-                        ART COMMUNITY
+                        ideart.
                     </Typography>
 
                     <Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>


### PR DESCRIPTION
* We changed our app's name as `ideart.` (styled this way) and therefore, updated all occurrences of the former name in both front-end and mobile.

* The style format we followed was mentioned in the tracking issue in detail but it was like as follows:
  ```
  fontFamily: 'monospace',
  fontWeight: 700,
  letterSpacing: '.2rem',
  ```

* More details about the progress and example screenshots after the final development can be found in the tracking issue #350.