### PR TITLE
[Mobile] Added .env file for server configuration

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -42,3 +42,5 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+.env

--- a/android/lib/config/api_endpoints.dart
+++ b/android/lib/config/api_endpoints.dart
@@ -1,6 +1,9 @@
-const int serverPort = 8080;
-const String baseURL = "http://10.0.2.2:$serverPort";
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
-const String registerURL = "$baseURL/signup";
-const String loginURL = "$baseURL/login";
-const String eventURL = "$baseURL/event";
+String serverPort = dotenv.env['SERVER_PORT'] ?? "8080";
+String serverIP = dotenv.env['SERVER_IP'] ?? "http://10.0.2.2";
+String baseURL = "$serverIP:$serverPort/api";
+
+String registerURL = "$baseURL/signup";
+String loginURL = "$baseURL/login";
+String eventURL = "$baseURL/event";

--- a/android/lib/main.dart
+++ b/android/lib/main.dart
@@ -4,11 +4,13 @@ import 'package:android/providers/register_provider.dart';
 import 'package:android/providers/user_provider.dart';
 import 'package:android/shared_prefs/user_preferences.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:provider/provider.dart';
 
 import '/config/app_routes.dart';
 
-void main() {
+void main() async {
+  await dotenv.load(fileName: ".env");
   runApp(const MyApp());
 }
 

--- a/android/pubspec.lock
+++ b/android/pubspec.lock
@@ -76,6 +76,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.2"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/android/pubspec.yaml
+++ b/android/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   provider: ^6.0.1
   country_picker: ^2.0.16
   http: ^0.13.5
+  flutter_dotenv: ^5.0.2
 
 dev_dependencies:
   flutter_test:
@@ -65,9 +66,8 @@ flutter:
   uses-material-design: true
 
   # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
+  assets:
+    - .env
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware

--- a/android/template.env
+++ b/android/template.env
@@ -1,0 +1,2 @@
+SERVER_IP=""
+SERVER_PORT=""


### PR DESCRIPTION
As mentioned in https://github.com/bounswe/bounswe2022group7/issues/357, I have added an env library, integrated it with the app and created a template.env file to show the expected fields in the .env file. If fields in the env file are empty, ip and port number defaults to localhost 8080.