### PR TITLE
Add form layout

### DIFF
--- a/frontend/src/layouts/FormLayout.js
+++ b/frontend/src/layouts/FormLayout.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { CssBaseline, Paper } from '@mui/material';
+
+const styles = {
+  main: {
+    width: 'auto',
+    display: 'block', // Fix IE 11 issue.
+    marginLeft: 100,
+    marginRight: 100,
+  },
+  paper: {
+    marginTop: 10,
+    paddingBottom: 20,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    p: 2,
+    width: 500,
+    marginLeft: "auto",
+    marginRight: "auto",
+  },
+};
+
+const FormLayout =({children}) =>{
+  
+  return (
+    <main SX={styles.main}>
+      <CssBaseline />
+      <Paper sx={styles.paper} elevation={5}>
+        {children}
+      </Paper>
+    </main>
+  );
+}
+
+export default FormLayout;

--- a/frontend/src/layouts/FormLayout.js
+++ b/frontend/src/layouts/FormLayout.js
@@ -26,7 +26,7 @@ const FormLayout =({children}) =>{
   return (
     <main SX={styles.main}>
       <CssBaseline />
-      <Paper sx={styles.paper} elevation={5}>
+      <Paper sx={styles.paper} variant="outlined">
         {children}
       </Paper>
     </main>

--- a/frontend/src/pages/Authentication/SignInPage.js
+++ b/frontend/src/pages/Authentication/SignInPage.js
@@ -14,6 +14,7 @@ import TextField from "@mui/material/TextField";
 import Paper from "@mui/material/Paper";
 import Stack from '@mui/material/Stack';
 import Typography from "@mui/material/Typography";
+import FormLayout from "../../layouts/FormLayout";
 
 const validationSchema = Yup.object().shape({
   email: Yup.string().email().required(),
@@ -83,14 +84,13 @@ function SignInForm(props) {
 
   return (
     <div>
-      <Paper sx={{p: 2}}>
         <Typography variant="h5" component="h3">
           {props.formName}
         </Typography>
         <Typography component="p">{props.formDescription}</Typography>
 
         <form onSubmit={formik.handleSubmit}>
-          <Stack sx={{mt: 2}}>
+          <Stack sx={{ padding: 2 }}>
             { error ? <Alert severity="error" sx={{ mb: 2 }}><AlertTitle>Error signing in</AlertTitle>{error}</Alert> :           
                redirected ? <Alert severity="info" sx={{mb: 2}}>You have succesfully signed up, you can login with your crediantials.</Alert> : null}
             <TextField
@@ -127,17 +127,18 @@ function SignInForm(props) {
             </Button>
           </Stack>
         </form>
-      </Paper>
-    </div>
+      </div>
   );
 }
 
 function SignInPage() {
   return (
-    <SignInForm
-      formName="Sign In"
-      formDescription="You can sign in to your account through this page."
-    />
+    <FormLayout>
+      <SignInForm
+        formName="Sign In"
+        formDescription="You can sign in to your account through this page."
+      />
+    </FormLayout>
   )
 }
 

--- a/frontend/src/pages/Authentication/SignUpPage.js
+++ b/frontend/src/pages/Authentication/SignUpPage.js
@@ -15,6 +15,7 @@ import MenuItem from '@mui/material/MenuItem';
 import InputLabel from '@mui/material/InputLabel';
 import { useFormik } from 'formik';
 import * as yup from 'yup';
+import FormLayout from "../../layouts/FormLayout";
 
 const validationSchema = yup.object({
   email: yup
@@ -124,7 +125,6 @@ function SignUpForm(props) {
 
   return (
     <div>
-      <Paper>
         <Typography variant="h5" component="h3">
           {props.formName}
         </Typography>
@@ -231,19 +231,18 @@ function SignUpForm(props) {
             </Button>
           </Stack>
         </form>
-      </Paper>
     </div>
   );
 }
 
 function SignUpPage() {
   return (
-    <div>
+    <FormLayout>
       <SignUpForm
         formName="Sign Up"
         formDescription="You can sign up to the platform through this page."
       />
-    </div>
+    </FormLayout>
   )
 }
 


### PR DESCRIPTION
Our signin and signup forms occupied the whole screen horizontally. You can see them in #284. I defined a layout for forms and updated the signin and signup pages.

Here isi how they look now:

![image](https://user-images.githubusercontent.com/57228345/200493298-3d28304a-1577-43e4-bcb7-8582c23d9f96.png)

![image](https://user-images.githubusercontent.com/57228345/200493348-211b27f7-8bf9-4482-9871-a17ffe336357.png)
