### PR TITLE
Merge swagger configuration to develop

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -2,3 +2,4 @@
 target
 .DS_Store
 .idea
+.mvn

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -101,6 +101,11 @@
 			<artifactId>springdoc-openapi-ui</artifactId>
 			<version>1.6.12</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-security</artifactId>
+			<version>1.6.12</version>
+		</dependency>
 		 <dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-kotlin</artifactId>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -96,12 +96,23 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-ui</artifactId>
+			<version>1.6.12</version>
+		</dependency>
+		 <dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-kotlin</artifactId>
+			<version>1.6.12</version>
+		 </dependency>
 	</dependencies>
 
 	<build>
 		<sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
 		<testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
 		<plugins>
+
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>

--- a/backend/src/main/kotlin/com/group7/artshare/configuration/OpenAPIConfiguration.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/configuration/OpenAPIConfiguration.kt
@@ -1,0 +1,34 @@
+package com.group7.artshare.configuration.documentation
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.util.StringUtils
+
+@Configuration
+class OpenApi30Config {
+    @Bean
+    fun customOpenAPI(): OpenAPI {
+        val securitySchemeName = "bearerAuth"
+        val apiTitle: String = "ideart. API"
+        val apiDescription : String = "ideart. API Placeholder Text"
+        return OpenAPI()
+            .components(
+                Components()
+                    .addSecuritySchemes(
+                        securitySchemeName,
+                        SecurityScheme()
+                            .name(securitySchemeName)
+                            .type(SecurityScheme.Type.HTTP)
+                            .scheme("bearer")
+                            .bearerFormat("JWT")
+                    )
+            )
+            .info(Info().title(apiTitle).version("1.0").description(apiDescription))
+    }
+}

--- a/backend/src/main/kotlin/com/group7/artshare/configuration/SecurityConfiguration.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/configuration/SecurityConfiguration.kt
@@ -41,6 +41,8 @@ class SecurityConfiguration @Autowired constructor(
     override fun configure(http: HttpSecurity) {
         http
             .authorizeRequests()
+            .antMatchers("/v3/api-docs", "/configuration/ui", "/swagger-resources/**", "/configuration/**", "/swagger-ui.html", "/webjars/**").permitAll()
+            .regexMatchers(".*swagger.*").permitAll()
             .antMatchers(HttpMethod.POST,"/login").permitAll()
             .antMatchers(HttpMethod.POST,"/signup").permitAll()
             .mvcMatchers(HttpMethod.GET, "/event/{id}").permitAll()

--- a/backend/src/main/kotlin/com/group7/artshare/controller/DataProp.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/controller/DataProp.kt
@@ -12,10 +12,15 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.*
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 
 @RestController
 @CrossOrigin(origins = ["*"], allowedHeaders = ["*"])
 @RequestMapping("data")
+@Tag(name = "Mock Data", description = "Created Mock data")
+@SecurityRequirement(name = "bearerAuth")
 class DataProp {
 
     @Autowired
@@ -168,7 +173,5 @@ class DataProp {
 
         return true
     }
-
-
 
 }

--- a/docker/backend.development.Dockerfile
+++ b/docker/backend.development.Dockerfile
@@ -1,7 +1,5 @@
 
 FROM maven:3.8.6-eclipse-temurin-17
-RUN addgroup devgroup; adduser --ingroup devgroup --disabled-password developer
-USER developer
 WORKDIR /app
 COPY ./pom.xml .
 COPY ./src/ ./src


### PR DESCRIPTION
I have finished implementation and configuration of OpenAPI 3.0 for our backend with the package `openapi-ui` as specified in issue #399. So the changes should be merged as soon as possible to help the frontend and mobile teams in integration of api endpoints. 


I have used several resources for implementation and questions for this issue: [Enabling authentication](https://stackoverflow.com/questions/59898874/enable-authorize-button-in-springdoc-openapi-ui-for-bearer-token-authentication), [implementation](https://www.baeldung.com/spring-rest-openapi-documentation) and [swagger-ui documentation](https://springdoc.org)

The resulting documentation UI can be accessed at api path: `api/swagger-ui/index.html`. The documentation can also be accessed in JSON format from the path `/api/v3/api-docs`

Merging this PR closes #399.

## User Interface:

<img width="1508" alt="resim" src="https://user-images.githubusercontent.com/26660856/201684522-1bb6204c-f628-419b-964e-7278be86bdbe.png">

- This is the general UI when the page is opened. The endpoints with a 🔒 sign next to them means that it is protected with authorization (JWT Bearer in our case). To try these endpoints firstly a person need to click to lock (🔒) or authorize buttons.

<img width="661" alt="resim" src="https://user-images.githubusercontent.com/26660856/201684587-d9e46fe9-49a6-4ae6-84c3-c1e67dd9884a.png">

- This window opens after an user tries to authorize, in which you should enter your JWT Bearer Token. After succesfull authorization the locks will be bold, and those endpoints will be open for testing from UI.

#### Endpoint Details (Expanded)

<img width="1438" alt="resim" src="https://user-images.githubusercontent.com/26660856/201684784-1e4bcccc-02cd-4a5c-9771-178c18436583.png">

## Implementation 

### Security

To add authorization to a respective controller or controller method(GET, POST, PUT, etc.) a developer should add this annotation to method/class with the import:

```kotlin
import io.swagger.v3.oas.annotations.security.SecurityRequirement;

...

@SecurityRequirement(name = "bearerAuth")
class ClassName { }
```

### Tagging

To add tags to endpoints or controllers( Tags are used for grouping endpoints and can include description of endpoints) following annotation with import should be added to top of controller classes or methods:

```kotlin
import io.swagger.v3.oas.annotations.tags.Tag;

...

@Tag(name = "Name", description = "Description")
class ClassName { }
```

### Endpoint description

To describe endpoints the annotation @Operation and @ApiResponse can be used in methods:

```kotlin
@Operation(summary = "Get a book by its id")
@ApiResponses(value = { 
  @ApiResponse(responseCode = "200", description = "Found the book", 
    content = { @Content(mediaType = "application/json", 
      schema = @Schema(implementation = Book.class)) }),
  @ApiResponse(responseCode = "400", description = "Invalid id supplied", 
    content = @Content), 
  @ApiResponse(responseCode = "404", description = "Book not found", 
    content = @Content) })
@GetMapping("/{id}")
public Book findById(@Parameter(description = "id of book to be searched") 
  @PathVariable long id) {
    return repository.findById(id).orElseThrow(() -> new BookNotFoundException());
}
```

### Hiding/Excluding

To hide certain endpoints and controllers the `@Hidden` annotation could be used:

```kotlin
import io.swagger.v3.oas.annotations.Hidden;

...

@Hidden
class testClass {}
```