### PR TITLE
[Mobile] Fix `.env` issue in Event Page widget test

### DIFF
--- a/android/test/widget_test/event_page_test.dart
+++ b/android/test/widget_test/event_page_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:nock/nock.dart';
@@ -11,6 +12,10 @@ import 'package:android/config/api_endpoints.dart';
 Widget makeTestableWidget() => MaterialApp(home: Image.network(''));
 
 void main() {
+  dotenv.testLoad(fileInput: '''SERVER_PORT=8080
+SERVER_IP=http://10.0.2.2
+''');
+
   setUpAll(nock.init);
 
   setUp(() {


### PR DESCRIPTION
The reason for this hotfix was explained in #405. Details can be found there.

After this PR:
- The issue mentioned was resolved.
- Only the `event_page_test.dart` file has been modified.
- The tests ran successfully after the update.

We can use `dotenv.testLoad()` function whenever we need to use the `.env` configuration in our widget tests. 

**FYI:** After this pull request is merged, you can continue with your work in CI development @erimerkin. 