### PR TITLE
Content Layout and Improvements

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -46,7 +46,14 @@ function App() {
             path="/new/art_item"
             element={<ProtectedRoute><CreateArtItemPage /></ProtectedRoute>} 
           />
-          <Route path="*" element={<ErrorPage />} />
+          <Route
+            path="*"
+            element={
+              <ErrorPage
+                message="It looks like you are trying to access a page that doesn't exist."
+              />
+              }
+            />
         </Routes>
       </AuthProvider>
     </div>

--- a/frontend/src/auth/ProtectedRoute.js
+++ b/frontend/src/auth/ProtectedRoute.js
@@ -1,12 +1,20 @@
 import React from "react";
-import { Navigate } from "react-router-dom";
 import { useAuth } from "./useAuth";
+import ErrorPage from '../pages/ErrorPage';
 
 export const ProtectedRoute = ({ children }) => {
   const { token } = useAuth();
   if (!token) {
     // user is not authenticated
-    return <Navigate to="/" />;
+    return (    
+        <ErrorPage
+          message="You are not authorised to access this page. Please login."
+          hyperlink={{
+            to: "/auth/signin",
+            text: "Go to Login Page"
+          }}
+          />
+      )
   }
   return children;
 };

--- a/frontend/src/common/CommentSection.js
+++ b/frontend/src/common/CommentSection.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import Box from '@mui/material/Box';
-import Stack from '@mui/material/Stack';
-import Typography from '@mui/material/Typography';
+
+import {Stack, Typography, Paper} from '@mui/material';
 
 import UserCard from './UserCard'
 import NewComment from './NewComment'
@@ -13,12 +12,10 @@ function CommentSection(props) {
   let commentComponents = props.commentList.map(commentData => UserCard(commentData))
   const {token} = useAuth() 
   return (
-    <Box sx={{
-      width: '90%',
-      paddingX: 1,
-      paddingY: 2,
-      borderRadius: 1,
-      boxShadow: 2,
+    <Paper style={{
+      width: '98%',
+      marginTop: 5,
+      marginLeft: "1%"
     }}>
       <Typography variant="h6">
         Comment Section of id={props.id}
@@ -29,7 +26,7 @@ function CommentSection(props) {
         {token && <NewComment />}
         
       </Stack>
-    </Box>
+    </Paper>
   );
 }
 

--- a/frontend/src/layouts/ContentLayout.js
+++ b/frontend/src/layouts/ContentLayout.js
@@ -1,19 +1,16 @@
 import React from 'react';
-import { CssBaseline, Paper } from '@mui/material';
+import { Paper } from '@mui/material';
 
 const styles = {
   main: {
     width: 'auto',
     display: 'block', // Fix IE 11 issue.
-    marginLeft: 100,
-    marginRight: 100,
   },
   paper: {
     marginTop: 3,
     paddingBottom: 20,
     flexDirection: 'column',
     alignItems: 'center',
-    p: 2,
     maxWidth: "95vh",
     width: "100%",
     marginLeft: "auto",

--- a/frontend/src/layouts/ContentLayout.js
+++ b/frontend/src/layouts/ContentLayout.js
@@ -14,7 +14,8 @@ const styles = {
     flexDirection: 'column',
     alignItems: 'center',
     p: 2,
-    width: 900,
+    maxWidth: "95vh",
+    width: "100%",
     marginLeft: "auto",
     marginRight: "auto",
   },
@@ -23,8 +24,8 @@ const styles = {
 const ContentLayout =({children}) =>{
   
   return (
-    <main SX={styles.main}>
-      <Paper sx={styles.paper} variant="outlined">
+    <main style={styles.main}>
+      <Paper style={styles.paper} variant="outlined">
         {children}
       </Paper>
     </main>

--- a/frontend/src/layouts/ContentLayout.js
+++ b/frontend/src/layouts/ContentLayout.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { CssBaseline, Paper } from '@mui/material';
+
+const styles = {
+  main: {
+    width: 'auto',
+    display: 'block', // Fix IE 11 issue.
+    marginLeft: 100,
+    marginRight: 100,
+  },
+  paper: {
+    marginTop: 3,
+    paddingBottom: 20,
+    flexDirection: 'column',
+    alignItems: 'center',
+    p: 2,
+    width: 900,
+    marginLeft: "auto",
+    marginRight: "auto",
+  },
+};
+
+const ContentLayout =({children}) =>{
+  
+  return (
+    <main SX={styles.main}>
+      <Paper sx={styles.paper} variant="outlined">
+        {children}
+      </Paper>
+    </main>
+  );
+}
+
+export default ContentLayout;

--- a/frontend/src/pages/ArtItemPage/ArtItemPage.js
+++ b/frontend/src/pages/ArtItemPage/ArtItemPage.js
@@ -52,11 +52,11 @@ function ArtItemPage() {
         {artitem.artItemInfo.name}
       </Typography>
     
-      <Grid container>
-        <Grid item xs={6} sx={{padding:2}}>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sm={8}>
           <img src={artitem.artItemInfo.imageUrl} alt="Art Item" style={{width:'100%'}}/>
         </ Grid>
-        <Grid item xs={6} sx={{padding:2}}>
+        <Grid item xs={12} sm={4}>
           <Typography variant="h5">Owner:</Typography>
           <UserCard author={artitem.owner}/>
           
@@ -73,11 +73,11 @@ function ArtItemPage() {
 
 
         </ Grid>
-        <CommentSection
-          id={id}
-          commentList={artitem.commentList.filter(x => !!x.author)}
-        />
       </ Grid>  
+      <CommentSection
+        id={id}
+        commentList={artitem.commentList.filter(x => !!x.author)}
+      />
     </ContentLayout>
     
   )}

--- a/frontend/src/pages/ArtItemPage/ArtItemPage.js
+++ b/frontend/src/pages/ArtItemPage/ArtItemPage.js
@@ -4,6 +4,7 @@ import { useAuth } from "../../auth/useAuth"
 
 import CommentSection from "../../common/CommentSection"
 import UserCard from "../../common/UserCard"
+import ContentLayout from "../../layouts/ContentLayout";
 
 import { Typography, Grid } from '@mui/material';
 
@@ -46,7 +47,7 @@ function ArtItemPage() {
     return <div>Loading...</div>
   } else {
   return (
-    <div>
+    <ContentLayout>
       <Typography variant="h4" sx={{padding:2}}>
         {artitem.artItemInfo.name}
       </Typography>
@@ -77,7 +78,7 @@ function ArtItemPage() {
           commentList={artitem.commentList.filter(x => !!x.author)}
         />
       </ Grid>  
-    </div>
+    </ContentLayout>
     
   )}
 }

--- a/frontend/src/pages/ErrorPage.js
+++ b/frontend/src/pages/ErrorPage.js
@@ -1,14 +1,21 @@
 import React from 'react'
 import { Link } from 'react-router-dom';
 
-export default function ErrorPage() {
+export default function ErrorPage(props) {
 
   return (
     <div style={{textAlign:"center"}}>
       <h1>Oops!</h1>
-      <p>Sorry, an unexpected error has occurred.</p>
+      
       <p>
-        <Link to="/">Go to Home </Link>
+        {props.message || "Sorry, an unexpected error has occured."}</p>
+      <p>      
+        {
+        props.hyperlink ?
+          <Link to={props.hyperlink.to}>{props.hyperlink.text}</Link>
+        :
+          <Link to="/">Go to Home</Link>  
+        }
       </p>
     </div>
   );

--- a/frontend/src/pages/EventPage/EventPage.js
+++ b/frontend/src/pages/EventPage/EventPage.js
@@ -4,6 +4,7 @@ import { useAuth } from "../../auth/useAuth"
 
 import { Typography, Grid } from '@mui/material';
 import CommentSection from "../../common/CommentSection"
+import ContentLayout from "../../layouts/ContentLayout";
 
 function EventPage() {
   
@@ -43,7 +44,7 @@ function EventPage() {
     return <div>Loading...</div>
   } else {
   return (
-    <div>
+    <ContentLayout>
       <Typography variant="h4" sx={{padding:2}}>
         {event.eventInfo.title}
       </Typography>
@@ -70,7 +71,7 @@ function EventPage() {
           commentList={event.commentList.filter(x => !!x.author)}
         />
       </ Grid>  
-    </div>
+    </ContentLayout>
     
   )}
 }

--- a/frontend/src/pages/EventPage/EventPage.js
+++ b/frontend/src/pages/EventPage/EventPage.js
@@ -49,11 +49,11 @@ function EventPage() {
         {event.eventInfo.title}
       </Typography>
     
-      <Grid container>
-        <Grid item xs={6} sx={{padding:2}}>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sm={8}>
           <img src={event.eventInfo.posterUrl} alt="Event" style={{width:'100%'}}/>
         </ Grid>
-        <Grid item xs={6} sx={{padding:2}}>          
+        <Grid item xs={12} sm={4}>          
           <Typography variant="h5">Description:</Typography>
           <Typography variant="body1">{event.eventInfo.description}</Typography>
 
@@ -66,11 +66,11 @@ function EventPage() {
           <Typography variant="h5">Location:</Typography>
           <Typography variant="body1">{event.location.address}</Typography>
         </ Grid>
-        <CommentSection
-          id={id}
-          commentList={event.commentList.filter(x => !!x.author)}
-        />
       </ Grid>  
+      <CommentSection
+        id={id}
+        commentList={event.commentList.filter(x => !!x.author)}
+      />
     </ContentLayout>
     
   )}

--- a/frontend/src/pages/HomePage/HomePage.js
+++ b/frontend/src/pages/HomePage/HomePage.js
@@ -22,7 +22,7 @@ const HomePage = () => {
         }
         if (token) fetchArgs.headers = {Authorization: "Bearer " + token}
 
-        fetch('/api/homepage/getGenericArtItems', fetchArgs)
+        fetch('api/homepage/artItem', fetchArgs)
             .then((response) => response.json())
             .then((data) => {
                 console.count(data)
@@ -34,7 +34,7 @@ const HomePage = () => {
                     setError(error)
                 })
 
-        fetch('/api/homepage/getGenericEvents', fetchArgs)
+        fetch('api/homepage/event', fetchArgs)
             .then((response) => response.json())
             .then((data) => {
                 console.count(data)


### PR DESCRIPTION
With this PR, I am doing some improvements in the frontend. I am adding a new layout, updating request endpoints in the home page and finally improving the error page.

### New Layout

Previously, we covered all of the screen horizontally on the art items and events pages. I added a layout to limit the content. Here is how it looks:

![image](https://user-images.githubusercontent.com/57228345/202741916-a5fdb7c1-11ff-4fa8-96b5-cb2c2ab54e3e.png)

### Endpoint Updates on Home Page

Endpoints of the homepage were updated after the milestone. I updated the fetch requests to fix them.

### Error Page

I added two parameters to the error page. It can now be defined as follows:

```js
<ErrorPage
  message="You are not authorised to access this page. Please login."
  hyperlink={{
    to: "/auth/signin",
    text: "Go to Login Page"
}}
/>
```

The error page defined above looks like this:

![image](https://user-images.githubusercontent.com/57228345/202742398-26d386d0-c5d2-4c19-9d82-817e4d906c2a.png)

You can define the error page without providing message or hyperlink. If you don't provide a message, it will display a default message. If you don't provide a hyperlink, it will show a hyperlink to home.