### PR TITLE
Fix and update FormLayout for lower resolution and mobile screens

### DIFF
--- a/frontend/src/layouts/FormLayout.js
+++ b/frontend/src/layouts/FormLayout.js
@@ -25,7 +25,7 @@ const styles = {
 
 const FormLayout = ({ children }) => {
   return (
-    <main SX={styles.main}>
+    <main sx={styles.main}>
       <CssBaseline />
       <Paper sx={styles.paper} variant="outlined">
         <Container>

--- a/frontend/src/layouts/FormLayout.js
+++ b/frontend/src/layouts/FormLayout.js
@@ -1,33 +1,36 @@
 import React from 'react';
-import { CssBaseline, Paper } from '@mui/material';
+import { Container, CssBaseline, Paper } from '@mui/material';
 
 const styles = {
   main: {
     width: 'auto',
     display: 'block', // Fix IE 11 issue.
-    marginLeft: 100,
-    marginRight: 100,
+    margin: 'auto',
   },
   paper: {
-    marginTop: 10,
-    paddingBottom: 20,
+
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
-    p: 2,
-    width: 500,
+    marginTop: 4,
+    marginBottom: 4,
+    paddingTop: 4,
+    paddingBottom: 2,
+    maxWidth: 500, 
+    width: '95%',
     marginLeft: "auto",
     marginRight: "auto",
   },
 };
 
-const FormLayout =({children}) =>{
-  
+const FormLayout = ({ children }) => {
   return (
     <main SX={styles.main}>
       <CssBaseline />
       <Paper sx={styles.paper} variant="outlined">
-        {children}
+        <Container>
+          {children}
+        </Container>
       </Paper>
     </main>
   );


### PR DESCRIPTION
I have fixed the responsiveness of FormLayout as the problem was described in and if succesfully merged closes #422. 

The changes are:

- Margin and Padding values are modified as actual margin/padding is generally 8x of that amount (default spacing value for MUI).
- Container is added to wrap the children while handling responsiveness depending on layout and automatically centering the content
- Width is changed to %95 of screen while having set a maximumWidth for higher resolutions


## Sign-up Page

### High Resolution Desktop Screen

![resim](https://user-images.githubusercontent.com/26660856/202850037-d2bca467-de34-4fe7-9b13-09694cc2a4f3.png)


### Low Resolution Iphone SE2 screen
<img src="https://user-images.githubusercontent.com/26660856/202850371-d2fb9c47-2853-48bb-8443-8b5f75cf5885.png" height=750 >


## Login Page

### High Resolution Desktop Screen
![image](https://user-images.githubusercontent.com/26660856/202850074-24244197-c3b8-4bd1-b79f-2b935a633f41.png)

#### Iphone SE 2 Screen

<img src="https://user-images.githubusercontent.com/26660856/202850094-9a2da326-ff7f-4702-90a8-191de7450360.png" height=500 >