### PR TITLE
DiscussionPost and Comment endpoints

### DIFF
--- a/backend/src/main/kotlin/com/group7/artshare/configuration/SecurityConfiguration.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/configuration/SecurityConfiguration.kt
@@ -50,6 +50,8 @@ class SecurityConfiguration @Autowired constructor(
             .mvcMatchers(HttpMethod.GET, "/homepage/artItem").permitAll()
             .mvcMatchers(HttpMethod.GET, "/homepage/event").permitAll()
             .mvcMatchers(HttpMethod.GET, "/profile/{username}").permitAll()
+            .mvcMatchers(HttpMethod.GET, "/discussionForum").permitAll()
+            .mvcMatchers(HttpMethod.GET, "/discussion/{id}").permitAll()
             .anyRequest().authenticated()
             .and()
             .sessionManagement()

--- a/backend/src/main/kotlin/com/group7/artshare/controller/CommentController.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/controller/CommentController.kt
@@ -3,12 +3,10 @@ package com.group7.artshare.controller
 import com.group7.artshare.entity.*
 import com.group7.artshare.repository.*
 import com.group7.artshare.request.CommentRequest
-import com.group7.artshare.request.DiscussionPostRequest
 import com.group7.artshare.service.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
 
@@ -16,10 +14,10 @@ import org.springframework.web.server.ResponseStatusException
 @RestController
 @CrossOrigin(origins = ["*"], allowedHeaders = ["*"])
 @RequestMapping("comment")
-class CommentController (
+class CommentController(
     private val jwtService: JwtService,
     private val commentService: CommentService
-    ) {
+) {
 
     @Autowired
     lateinit var commentRepository: CommentRepository
@@ -29,8 +27,11 @@ class CommentController (
 
 
     @GetMapping("{id}")
-    fun getComment(@PathVariable("id") id: Long) : Comment = commentRepository.findByIdOrNull(id) ?:
-        throw ResponseStatusException(HttpStatus.NOT_FOUND, "Id is not match with any of the discussion posts in the database")
+    fun getComment(@PathVariable("id") id: Long): Comment =
+        commentRepository.findByIdOrNull(id) ?: throw ResponseStatusException(
+            HttpStatus.NOT_FOUND,
+            "Id is not match with any of the discussion posts in the database"
+        )
 
     @PostMapping(
         consumes = ["application/json;charset=UTF-8"],
@@ -60,17 +61,19 @@ class CommentController (
 
     @DeleteMapping("{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    fun deleteComment(@PathVariable id: Long,
-    @RequestBody json: Map<String,Long>,
-    @RequestHeader(
-        value = "Authorization",
-        required = true
-    ) authorizationHeader: String?): Unit? {
+    fun deleteComment(
+        @PathVariable id: Long,
+        @RequestBody json: Map<String, Long>,
+        @RequestHeader(
+            value = "Authorization",
+            required = true
+        ) authorizationHeader: String?
+    ){
         try {
             authorizationHeader?.let {
                 val user =
                     jwtService.getUserFromAuthorizationHeader(authorizationHeader) ?: throw Exception("Invalid token")
-                return json["commentedObjectId"]?.let { it1 -> commentService.deleteComment(id, it1, user) }
+                json["commentedObjectId"]?.let { it1 -> commentService.deleteComment(id, it1, user) }
             } ?: throw Exception("Token required")
         } catch (e: Exception) {
             if (e.message == "Invalid token") {

--- a/backend/src/main/kotlin/com/group7/artshare/controller/CommentController.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/controller/CommentController.kt
@@ -22,15 +22,11 @@ class CommentController(
     @Autowired
     lateinit var commentRepository: CommentRepository
 
-    @Autowired
-    lateinit var registeredUserRepository: RegisteredUserRepository
-
-
     @GetMapping("{id}")
     fun getComment(@PathVariable("id") id: Long): Comment =
         commentRepository.findByIdOrNull(id) ?: throw ResponseStatusException(
             HttpStatus.NOT_FOUND,
-            "Id is not match with any of the comments in the database"
+            "Id is not matched with any of the comments in the database"
         )
 
     @PostMapping(

--- a/backend/src/main/kotlin/com/group7/artshare/controller/CommentController.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/controller/CommentController.kt
@@ -1,0 +1,60 @@
+package com.group7.artshare.controller
+
+import com.group7.artshare.entity.*
+import com.group7.artshare.repository.*
+import com.group7.artshare.request.CommentRequest
+import com.group7.artshare.request.DiscussionPostRequest
+import com.group7.artshare.service.*
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.server.ResponseStatusException
+
+
+@RestController
+@CrossOrigin(origins = ["*"], allowedHeaders = ["*"])
+@RequestMapping("comment")
+class CommentController (
+    private val jwtService: JwtService,
+    private val commentService: CommentService
+    ) {
+
+    @Autowired
+    lateinit var commentRepository: CommentRepository
+
+    @GetMapping("{id}")
+    fun getComment(@PathVariable("id") id: Long) : Comment = commentRepository.findByIdOrNull(id) ?:
+        throw ResponseStatusException(HttpStatus.NOT_FOUND, "Id is not match with any of the discussion posts in the database")
+
+    @PostMapping(
+        consumes = ["application/json;charset=UTF-8"],
+        produces = ["application/json;charset=UTF-8"]
+    )
+    fun create(
+        @RequestBody commentRequest: CommentRequest,
+        @RequestHeader(
+            value = "Authorization",
+            required = true
+        ) authorizationHeader: String?
+    ): Comment {
+        try {
+            authorizationHeader?.let {
+                val user =
+                    jwtService.getUserFromAuthorizationHeader(authorizationHeader) ?: throw Exception("Invalid token")
+                return commentService.createComment(commentRequest, user)
+            } ?: throw Exception("Token required")
+        } catch (e: Exception) {
+            if (e.message == "Invalid token") {
+                throw ResponseStatusException(HttpStatus.UNAUTHORIZED, e.message)
+            } else {
+                throw ResponseStatusException(HttpStatus.BAD_REQUEST, e.message)
+            }
+        }
+    }
+
+    @DeleteMapping("{id}")
+    fun deleteComment(@PathVariable("id") id: Long) : Comment = commentRepository.findByIdOrNull(id) ?:
+    throw ResponseStatusException(HttpStatus.NOT_FOUND, "Id is not match with any of the discussion posts in the database")
+}

--- a/backend/src/main/kotlin/com/group7/artshare/controller/CommentController.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/controller/CommentController.kt
@@ -30,7 +30,7 @@ class CommentController(
     fun getComment(@PathVariable("id") id: Long): Comment =
         commentRepository.findByIdOrNull(id) ?: throw ResponseStatusException(
             HttpStatus.NOT_FOUND,
-            "Id is not match with any of the discussion posts in the database"
+            "Id is not match with any of the comments in the database"
         )
 
     @PostMapping(

--- a/backend/src/main/kotlin/com/group7/artshare/controller/DiscussionForumController.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/controller/DiscussionForumController.kt
@@ -1,0 +1,28 @@
+package com.group7.artshare.controller
+
+import com.group7.artshare.entity.*
+import com.group7.artshare.repository.ArtItemRepository
+import com.group7.artshare.repository.DiscussionPostRepository
+import com.group7.artshare.repository.OnlineGalleryRepository
+import com.group7.artshare.repository.PhysicalExhibitionRepository
+import com.group7.artshare.service.JwtService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.server.ResponseStatusException
+
+
+@RestController
+@CrossOrigin(origins = ["*"], allowedHeaders = ["*"])
+@RequestMapping("discussionForum")
+class DiscussionForumController() {
+
+    @Autowired
+    lateinit var discussionPostRepository: DiscussionPostRepository
+
+    @GetMapping()
+    fun getRecommendedEventsGeneric(): List<DiscussionPost> {
+        return discussionPostRepository.findAll()
+    }
+
+}

--- a/backend/src/main/kotlin/com/group7/artshare/controller/DiscussionPostController.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/controller/DiscussionPostController.kt
@@ -25,7 +25,7 @@ class DiscussionPostController (
 
     @GetMapping("{id}")
     fun getDiscussionPost(@PathVariable("id") id: Long) : DiscussionPost = discussionPostRepository.findByIdOrNull(id) ?:
-        throw ResponseStatusException(HttpStatus.NOT_FOUND, "Id is not match with any of the discussion posts in the database")
+        throw ResponseStatusException(HttpStatus.NOT_FOUND, "Id is not matched with any of the discussion posts in the database")
 
     @PostMapping(
         consumes = ["application/json;charset=UTF-8"],

--- a/backend/src/main/kotlin/com/group7/artshare/controller/DiscussionPostController.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/controller/DiscussionPostController.kt
@@ -52,4 +52,28 @@ class DiscussionPostController (
             }
         }
     }
+
+//    @DeleteMapping("{id}")
+//    @ResponseStatus(HttpStatus.NO_CONTENT)
+//    fun delete(
+//        @PathVariable id: Long,
+//        @RequestHeader(
+//            value = "Authorization",
+//            required = true
+//        ) authorizationHeader: String?
+//    ){
+//        try {
+//            authorizationHeader?.let {
+//                val user =
+//                    jwtService.getUserFromAuthorizationHeader(authorizationHeader) ?: throw Exception("Invalid token")
+//                discussionPostService.deleteDiscussionPost(id, user)
+//            } ?: throw Exception("Token required")
+//        } catch (e: Exception) {
+//            if (e.message == "Invalid token") {
+//                throw ResponseStatusException(HttpStatus.UNAUTHORIZED, e.message)
+//            } else {
+//                throw ResponseStatusException(HttpStatus.BAD_REQUEST, e.message)
+//            }
+//        }
+//    }
 }

--- a/backend/src/main/kotlin/com/group7/artshare/controller/DiscussionPostController.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/controller/DiscussionPostController.kt
@@ -1,0 +1,55 @@
+package com.group7.artshare.controller
+
+import com.group7.artshare.entity.*
+import com.group7.artshare.repository.*
+import com.group7.artshare.request.DiscussionPostRequest
+import com.group7.artshare.service.*
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.server.ResponseStatusException
+
+
+@RestController
+@CrossOrigin(origins = ["*"], allowedHeaders = ["*"])
+@RequestMapping("discussion")
+class DiscussionPostController (
+    private val jwtService: JwtService,
+    private val discussionPostService: DiscussionPostService
+    ) {
+
+    @Autowired
+    lateinit var discussionPostRepository: DiscussionPostRepository
+
+    @GetMapping("{id}")
+    fun getDiscussionPost(@PathVariable("id") id: Long) : DiscussionPost = discussionPostRepository.findByIdOrNull(id) ?:
+        throw ResponseStatusException(HttpStatus.NOT_FOUND, "Id is not match with any of the discussion posts in the database")
+
+    @PostMapping(
+        consumes = ["application/json;charset=UTF-8"],
+        produces = ["application/json;charset=UTF-8"]
+    )
+    fun create(
+        @RequestBody discussionPostRequest: DiscussionPostRequest,
+        @RequestHeader(
+            value = "Authorization",
+            required = true
+        ) authorizationHeader: String?
+    ): DiscussionPost {
+        try {
+            authorizationHeader?.let {
+                val user =
+                    jwtService.getUserFromAuthorizationHeader(authorizationHeader) ?: throw Exception("Invalid token")
+                return discussionPostService.createDiscussionPost(discussionPostRequest, user)
+            } ?: throw Exception("Token required")
+        } catch (e: Exception) {
+            if (e.message == "Invalid token") {
+                throw ResponseStatusException(HttpStatus.UNAUTHORIZED, e.message)
+            } else {
+                throw ResponseStatusException(HttpStatus.BAD_REQUEST, e.message)
+            }
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/group7/artshare/entity/Comment.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/entity/Comment.kt
@@ -15,7 +15,7 @@ class Comment {
     val id: Long = 0L
 
     @Column
-    var text : String = ""
+    var text: String? = null
 
     @Column
     @Temporal(TemporalType.TIMESTAMP)

--- a/backend/src/main/kotlin/com/group7/artshare/entity/DiscussionPost.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/entity/DiscussionPost.kt
@@ -1,5 +1,6 @@
 package com.group7.artshare.entity
 
+import com.fasterxml.jackson.annotation.JsonBackReference
 import lombok.Data
 import java.util.*
 import javax.persistence.*
@@ -23,6 +24,7 @@ class DiscussionPost {
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "creator")
+    @JsonBackReference
     var creator: RegisteredUser? = null
 
     @Column

--- a/backend/src/main/kotlin/com/group7/artshare/entity/DiscussionPost.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/entity/DiscussionPost.kt
@@ -13,13 +13,13 @@ class DiscussionPost {
     val id: Long = 0L
 
     @Column
-    var title: String = ""
+    var title: String? = null
 
     @Column
-    var textBody: String = ""
+    var textBody: String? = null
 
     @Column
-    var imageURL: String = ""
+    var posterId: Long? = null
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "creator")

--- a/backend/src/main/kotlin/com/group7/artshare/entity/RegisteredUser.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/entity/RegisteredUser.kt
@@ -95,7 +95,11 @@ open class RegisteredUser(
     )
     var unreadNotifications: MutableSet<Notification> = mutableSetOf()
 
-    //TODO discussion post
+
+    @OneToMany(orphanRemoval = true, cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+    @JsonManagedReference
+    var writtenDiscussionPosts: MutableList<DiscussionPost> = mutableListOf()
+
     //TODO past reply past posts
 
     @OneToMany(orphanRemoval = true, cascade = [CascadeType.ALL])

--- a/backend/src/main/kotlin/com/group7/artshare/repository/DiscussionPostRepository.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/repository/DiscussionPostRepository.kt
@@ -1,0 +1,10 @@
+package com.group7.artshare.repository
+import org.springframework.data.jpa.repository.JpaRepository
+import com.group7.artshare.entity.ArtItem
+import com.group7.artshare.entity.DiscussionPost
+import org.springframework.stereotype.Repository
+
+@Repository
+interface DiscussionPostRepository : JpaRepository<DiscussionPost, Long>{
+
+}

--- a/backend/src/main/kotlin/com/group7/artshare/request/CommentRequest.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/request/CommentRequest.kt
@@ -1,0 +1,17 @@
+package com.group7.artshare.request
+
+import lombok.Data
+import lombok.RequiredArgsConstructor
+import javax.validation.constraints.NotEmpty
+
+
+@Data
+@RequiredArgsConstructor
+class CommentRequest {
+
+    @NotEmpty
+    val text: String? = null
+
+    val commentedObjectId: Long? = null
+
+}

--- a/backend/src/main/kotlin/com/group7/artshare/request/DiscussionPostRequest.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/request/DiscussionPostRequest.kt
@@ -1,0 +1,20 @@
+package com.group7.artshare.request
+
+import lombok.Data
+import lombok.RequiredArgsConstructor
+import javax.validation.constraints.NotEmpty
+
+
+@Data
+@RequiredArgsConstructor
+class DiscussionPostRequest {
+
+    @NotEmpty
+    val title: String? = null
+
+    @NotEmpty
+    val textBody: String? = null
+
+    val posterId: Long? = null
+
+}

--- a/backend/src/main/kotlin/com/group7/artshare/service/CommentService.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/service/CommentService.kt
@@ -5,7 +5,6 @@ import com.group7.artshare.repository.*
 import com.group7.artshare.request.*
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.http.HttpStatus
-import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
 
@@ -23,23 +22,58 @@ class CommentService(
     ): Comment {
         val newComment = Comment()
         newComment.author = user
+
         val commentedObjectId = commentRequest.commentedObjectId
         newComment.text = commentRequest.text
-        if(commentedObjectId?.let { artItemRepository.existsById(it) } == true){
+        if (commentedObjectId?.let { artItemRepository.existsById(it) } == true) {
             artItemRepository.findByIdOrNull(commentedObjectId)?.commentList?.add(newComment)
-        }
-        else if(commentedObjectId?.let { onlineGalleryRepository.existsById(it) } == true){
+        } else if (commentedObjectId?.let { onlineGalleryRepository.existsById(it) } == true) {
             onlineGalleryRepository.findByIdOrNull(commentedObjectId)?.commentList?.add(newComment)
-        }
-        else if(commentedObjectId?.let { physicalExhibitionRepository.existsById(it) } == true){
+        } else if (commentedObjectId?.let { physicalExhibitionRepository.existsById(it) } == true) {
             physicalExhibitionRepository.findByIdOrNull(commentedObjectId)?.commentList?.add(newComment)
-        }
-        else if(commentedObjectId?.let { discussionPostRepository.existsById(it) } == true){
+        } else if (commentedObjectId?.let { discussionPostRepository.existsById(it) } == true) {
             discussionPostRepository.findByIdOrNull(commentedObjectId)?.commentList?.add(newComment)
-        }
-        else
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "There is no commentable object in the database with this id")
+        } else
+            throw ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                "There is no commentable object in the database with this id"
+            )
         commentRepository.save(newComment)
+        user.commentList.add(newComment)
         return newComment
+    }
+
+    fun deleteComment(
+        id: Long,
+        commentedObjectId: Long,
+        user: RegisteredUser
+    ) {
+        if (!commentRepository.existsById(id)) {
+            throw ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                "There is no comment object in the database with this id"
+            )
+        } else {
+            var comment: Comment? = user.commentList.firstOrNull { it.id == id }
+                ?: throw ResponseStatusException(
+                    HttpStatus.UNAUTHORIZED,
+                    "Associated comment is not written by this user"
+                )
+            user.commentList.remove(comment)
+            if (commentedObjectId.let { artItemRepository.existsById(it) }) {
+                artItemRepository.findByIdOrNull(commentedObjectId)?.commentList?.remove(comment)
+            } else if (commentedObjectId.let { onlineGalleryRepository.existsById(it) }) {
+                onlineGalleryRepository.findByIdOrNull(commentedObjectId)?.commentList?.remove(comment)
+            } else if (commentedObjectId.let { physicalExhibitionRepository.existsById(it) }) {
+                physicalExhibitionRepository.findByIdOrNull(commentedObjectId)?.commentList?.remove(comment)
+            } else if (commentedObjectId.let { discussionPostRepository.existsById(it) }) {
+                discussionPostRepository.findByIdOrNull(commentedObjectId)?.commentList?.remove(comment)
+            } else
+                throw ResponseStatusException(
+                    HttpStatus.BAD_REQUEST,
+                    "Comment is not associated with the given commented object id"
+                )
+            commentRepository.deleteById(id)
+        }
     }
 }

--- a/backend/src/main/kotlin/com/group7/artshare/service/CommentService.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/service/CommentService.kt
@@ -22,7 +22,7 @@ class CommentService(
     ): Comment {
         val newComment = Comment()
         newComment.author = user
-
+        user.commentList.add(newComment)
         val commentedObjectId = commentRequest.commentedObjectId
         newComment.text = commentRequest.text
         if (commentedObjectId?.let { artItemRepository.existsById(it) } == true) {
@@ -39,7 +39,6 @@ class CommentService(
                 "There is no commentable object in the database with this id"
             )
         commentRepository.save(newComment)
-        user.commentList.add(newComment)
         return newComment
     }
 

--- a/backend/src/main/kotlin/com/group7/artshare/service/CommentService.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/service/CommentService.kt
@@ -1,0 +1,45 @@
+package com.group7.artshare.service
+
+import com.group7.artshare.entity.*
+import com.group7.artshare.repository.*
+import com.group7.artshare.request.*
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
+
+@Service
+class CommentService(
+    private val commentRepository: CommentRepository,
+    private val artItemRepository: ArtItemRepository,
+    private val discussionPostRepository: DiscussionPostRepository,
+    private val onlineGalleryRepository: OnlineGalleryRepository,
+    private val physicalExhibitionRepository: PhysicalExhibitionRepository
+) {
+    fun createComment(
+        commentRequest: CommentRequest,
+        user: RegisteredUser
+    ): Comment {
+        val newComment = Comment()
+        newComment.author = user
+        val commentedObjectId = commentRequest.commentedObjectId
+        newComment.text = commentRequest.text
+        if(commentedObjectId?.let { artItemRepository.existsById(it) } == true){
+            artItemRepository.findByIdOrNull(commentedObjectId)?.commentList?.add(newComment)
+        }
+        else if(commentedObjectId?.let { onlineGalleryRepository.existsById(it) } == true){
+            onlineGalleryRepository.findByIdOrNull(commentedObjectId)?.commentList?.add(newComment)
+        }
+        else if(commentedObjectId?.let { physicalExhibitionRepository.existsById(it) } == true){
+            physicalExhibitionRepository.findByIdOrNull(commentedObjectId)?.commentList?.add(newComment)
+        }
+        else if(commentedObjectId?.let { discussionPostRepository.existsById(it) } == true){
+            discussionPostRepository.findByIdOrNull(commentedObjectId)?.commentList?.add(newComment)
+        }
+        else
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "There is no commentable object in the database with this id")
+        commentRepository.save(newComment)
+        return newComment
+    }
+}

--- a/backend/src/main/kotlin/com/group7/artshare/service/DiscussionPostService.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/service/DiscussionPostService.kt
@@ -20,6 +20,7 @@ class DiscussionPostService(
     ): DiscussionPost {
         val newDiscussionPost = DiscussionPost()
         newDiscussionPost.creator = user
+        user.writtenDiscussionPosts.add(newDiscussionPost)
         if(discussionPostRequest.posterId?.let { imageRepository.existsById(it) } == false)
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "There is no image in the database with this id")
         newDiscussionPost.posterId = discussionPostRequest.posterId
@@ -28,5 +29,25 @@ class DiscussionPostService(
         discussionPostRepository.save(newDiscussionPost)
         return newDiscussionPost
     }
+//    fun deleteDiscussionPost(
+//        id: Long,
+//        user: RegisteredUser
+//    ) {
+//        if (!discussionPostRepository.existsById(id)) {
+//            throw ResponseStatusException(
+//                HttpStatus.BAD_REQUEST,
+//                "There is no discussion post object in the database with this id"
+//            )
+//        } else {
+//            var discussionPost: DiscussionPost? = user.writtenDiscussionPosts.firstOrNull { it.id == id }
+//                ?: throw ResponseStatusException(
+//                    HttpStatus.UNAUTHORIZED,
+//                    "Associated discussion post is not written by this user"
+//                )
+//            user.writtenDiscussionPosts.remove(discussionPost)
+//            discussionPostRepository.deleteById(id)
+//        }
+//    }
+
 
 }

--- a/backend/src/main/kotlin/com/group7/artshare/service/DiscussionPostService.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/service/DiscussionPostService.kt
@@ -1,0 +1,32 @@
+package com.group7.artshare.service
+
+import com.group7.artshare.entity.*
+import com.group7.artshare.repository.*
+import com.group7.artshare.request.*
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
+
+@Service
+class DiscussionPostService(
+    private val discussionPostRepository: DiscussionPostRepository,
+    private val imageRepository: ImageRepository
+) {
+    fun createDiscussionPost(
+        discussionPostRequest: DiscussionPostRequest,
+        user: RegisteredUser
+    ): DiscussionPost {
+        val newDiscussionPost = DiscussionPost()
+        newDiscussionPost.creator = user
+        if(discussionPostRequest.posterId?.let { imageRepository.existsById(it) } == false)
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "There is no image in the database with this id")
+        newDiscussionPost.posterId = discussionPostRequest.posterId
+        newDiscussionPost.title = discussionPostRequest.title
+        newDiscussionPost.textBody = discussionPostRequest.textBody
+        discussionPostRepository.save(newDiscussionPost)
+        return newDiscussionPost
+    }
+
+}


### PR DESCRIPTION
I implemented the endpoints from [the issue](https://github.com/bounswe/bounswe2022group7/issues/438). These endpoints from the future week's tasks and I thought discussing its design beforehand may facilitates the FrontEnd and Mobile team's work.

Get endpoints are pretty straightforward and implemented according to the [meeting notes](https://github.com/bounswe/bounswe2022group7/wiki/CMPE451-Meeting-Notes-%236)

There are two POST endpoints, one for Comment and one for DiscussionPost

1. DiscussionPost:
```json
{
  "title": "string",
  "textBody": "string",
  "posterId": 0
}
```
2. Comment:
```json
{
  "text": "string",
  "commentedObjectId": 0
}
```

Please review and inform me about any changes request about the structures @CahidArda @atillaturkmen. If we agree on the structure, then we can merge it after review @demet47 