### PR TITLE
Fix Image Auth and Wrong Spelling

### DIFF
--- a/backend/src/main/kotlin/com/group7/artshare/configuration/SecurityConfiguration.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/configuration/SecurityConfiguration.kt
@@ -52,6 +52,7 @@ class SecurityConfiguration @Autowired constructor(
             .mvcMatchers(HttpMethod.GET, "/profile/{username}").permitAll()
             .mvcMatchers(HttpMethod.GET, "/discussionForum").permitAll()
             .mvcMatchers(HttpMethod.GET, "/discussion/{id}").permitAll()
+            .mvcMatchers(HttpMethod.GET, "/image/{id}").permitAll()
             .anyRequest().authenticated()
             .and()
             .sessionManagement()

--- a/backend/src/main/kotlin/com/group7/artshare/entity/Location.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/entity/Location.kt
@@ -12,7 +12,7 @@ class Location {
     val id: Long = 0L
 
     @Column
-    var lattitude: Double = 0.0
+    var latitude: Double = 0.0
 
     @Column
     var longitude: Double = 0.0


### PR DESCRIPTION
Implamentation of the [Bug Fix Issue](https://github.com/bounswe/bounswe2022group7/issues/449)

GET Image endpoint is not required authorization
"Lattitude" field of Location is updated to "Latitude"