### PR TITLE
Remove poster from discussion post

### DIFF
--- a/backend/src/main/kotlin/com/group7/artshare/entity/DiscussionPost.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/entity/DiscussionPost.kt
@@ -55,7 +55,6 @@ class DiscussionPost {
         discussionPostDTO.id = this.id
         discussionPostDTO.title = this.title
         discussionPostDTO.textBody = this.textBody
-        discussionPostDTO.posterId = this.posterId
         discussionPostDTO.creationDate = this.creationDate
         discussionPostDTO.lastEditDate = this.lastEditDate
         discussionPostDTO.upvoteNo = this.upvoteNo

--- a/backend/src/main/kotlin/com/group7/artshare/entity/DiscussionPost.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/entity/DiscussionPost.kt
@@ -23,9 +23,6 @@ class DiscussionPost {
     @Column
     var textBody: String? = null
 
-    @Column
-    var posterId: Long? = null
-
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "creator")
     @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator::class, property = "id")

--- a/backend/src/main/kotlin/com/group7/artshare/request/DiscussionPostRequest.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/request/DiscussionPostRequest.kt
@@ -15,6 +15,4 @@ class DiscussionPostRequest {
     @NotEmpty
     val textBody: String? = null
 
-    val posterId: Long? = null
-
 }

--- a/backend/src/main/kotlin/com/group7/artshare/service/DiscussionPostService.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/service/DiscussionPostService.kt
@@ -21,9 +21,6 @@ class DiscussionPostService(
         val newDiscussionPost = DiscussionPost()
         newDiscussionPost.creator = user
         user.writtenDiscussionPosts.add(newDiscussionPost)
-        if(discussionPostRequest.posterId?.let { imageRepository.existsById(it) } == false)
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "There is no image in the database with this id")
-        newDiscussionPost.posterId = discussionPostRequest.posterId
         newDiscussionPost.title = discussionPostRequest.title
         newDiscussionPost.textBody = discussionPostRequest.textBody
         discussionPostRepository.save(newDiscussionPost)


### PR DESCRIPTION
Currently, the discussion posts have a poster field. This is not necessary and can be removed. This was a fairly simple update and I didn't want to bother the backend team and tried to do it myself.

I removed poster from discussion posts and tried to use the endpoints by creating and viewing discussion posts. I believe it works.