### PR TITLE
Add Discussion Post

### DIFF
--- a/backend/src/main/kotlin/com/group7/artshare/DTO/DiscussionPostDTO.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/DTO/DiscussionPostDTO.kt
@@ -1,5 +1,6 @@
 package com.group7.artshare.DTO
 
+import com.group7.artshare.entity.AccountInfo
 import lombok.Data
 import java.util.Date
 
@@ -8,6 +9,8 @@ class DiscussionPostDTO{
     var id : Long? = null
     var title : String? = null
     var textBody : String? = null
+    var creatorAccountInfo : AccountInfo? = null
+    var creatorId : Long? = null
     var posterId : Long? = null
     var creationDate : Date? = null
     var lastEditDate : Date? = null

--- a/backend/src/main/kotlin/com/group7/artshare/entity/DiscussionPost.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/entity/DiscussionPost.kt
@@ -55,6 +55,8 @@ class DiscussionPost {
         discussionPostDTO.id = this.id
         discussionPostDTO.title = this.title
         discussionPostDTO.textBody = this.textBody
+        discussionPostDTO.creatorAccountInfo = this.creator?.accountInfo
+        discussionPostDTO.creatorId = this.creator?.id
         discussionPostDTO.creationDate = this.creationDate
         discussionPostDTO.lastEditDate = this.lastEditDate
         discussionPostDTO.upvoteNo = this.upvoteNo

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,6 +17,8 @@ import SettingsPage from './pages/ProfilePage/SettingsPage';
 import { AuthProvider } from './auth/useAuth';
 import {ProtectedRoute} from './auth/ProtectedRoute';
 import CreatePhysicalEventPage from './pages/EventPage/CreatePhysicalEventPage';
+import CreateDiscussionPostPage from './pages/DiscussionPage/CreateDiscussionPostPage';
+import DiscussionPostPage from './pages/DiscussionPage/DiscussionPostPage';
 
 function App() {
   return (
@@ -55,6 +57,14 @@ function App() {
           <Route
             path="/event/:id"
             element={<EventPage />}
+          />
+          <Route
+            path="/discussionPost/new"
+            element={<CreateDiscussionPostPage />}
+          />
+          <Route
+            path="/discussionPost/:id"
+            element={<DiscussionPostPage />}
           />
           <Route
             path="/profile/settings"

--- a/frontend/src/common/CommentSection.js
+++ b/frontend/src/common/CommentSection.js
@@ -5,12 +5,10 @@ import {Stack, Typography, Paper} from '@mui/material';
 import UserCard from './UserCard'
 import NewComment from './NewComment'
 
-import {useAuth} from "../auth/useAuth"
-
 function CommentSection(props) {
   
-  let commentComponents = props.commentList.map(commentData => UserCard(commentData))
-  const {token} = useAuth() 
+  let commentComponents = props.commentList.map(comment => <UserCard data={comment} key={comment.id}></UserCard>)
+  
   return (
     <Paper style={{
       width: '98%',
@@ -18,12 +16,12 @@ function CommentSection(props) {
       marginLeft: "1%"
     }}>
       <Typography variant="h6">
-        Comment Section of id={props.id}
+        Comment Section
       </Typography>
 
       <Stack spacing={2}>
         {commentComponents}
-        {token && <NewComment />}
+        <NewComment contentId={props.contentId}/>
         
       </Stack>
     </Paper>

--- a/frontend/src/common/NewComment.js
+++ b/frontend/src/common/NewComment.js
@@ -2,27 +2,80 @@ import React from 'react';
 
 import Card from '@mui/material/Card';
 import { CardContent } from '@mui/material';
-import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
 
-function NewComment() {
-  return (
-    <Card sx={{
-      width: '%90',
-      padding: 2
-    }}>
-      <CardContent>
-        <TextField
-          fullWidth
-          id="outlined-multiline-static"
-          multiline
-          rows={4}
-          label="Enter Your Comment Here"
-        />
-        <Button variant="contained">Send Comment</Button>
-      </CardContent>  
-    </Card>
-  )
+import {useAuth} from "../auth/useAuth"
+import LoadingButton from '../components/LoadingButton';
+
+function NewComment(props) {
+
+  const {token} = useAuth()
+  const [newCommentState, setNewCommentState] = React.useReducer(
+    (state, newState) => ({ ...state, ...newState }),
+    {
+      isLoading: false,
+      text: ""
+    }
+  );
+
+  if (!token) {
+    return
+  } else {
+    const handleSubmit = (event) => {
+      event.preventDefault();
+      setNewCommentState({isLoading: true})
+      const {contentId} = props
+
+      fetch("/api/comment", {
+        method: "POST",
+        body: JSON.stringify({
+          text: newCommentState.text,
+          commentedObjectId: contentId 
+        }),
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": "Bearer " + token
+        }
+      })
+        .then(response => window.location.reload())
+    }
+
+    const handleInput = event => {
+      const name = event.target.name;
+      const newValue = event.target.value;
+      setNewCommentState({ [name]: newValue });
+    };
+
+    return (
+      <Card sx={{
+        width: '%90',
+        padding: 2
+      }}>
+        <CardContent>
+          <form onSubmit={handleSubmit}>
+            <TextField
+              fullWidth
+              id="outlined-multiline-static"
+              multiline
+              name="text"
+              defaultValue={newCommentState.text}
+              onChange={handleInput}
+              rows={4}
+              label="Enter Your Comment Here"
+            />
+            <LoadingButton
+              loading={newCommentState.isLoading}
+              label="Add Comment"
+              loadingText="Adding Comment"
+              type="submit"
+              variant="contained"
+              color="primary"
+            />
+          </form>
+        </CardContent>  
+      </Card>
+    )
+  }
 }
 
 export default NewComment

--- a/frontend/src/common/UserCard.js
+++ b/frontend/src/common/UserCard.js
@@ -11,7 +11,10 @@ import StarOutlineIcon from '@mui/icons-material/StarOutline';
 
 function UserCard(props) {
 
-  const { author, body, createdAt } = props
+  let { authorAccountInfo, text, creationDate } = props.data
+  if (!authorAccountInfo) { //this is not a comment. It's a user card
+    authorAccountInfo = props.data
+  }
 
   const { token } = useAuth()
 
@@ -27,7 +30,7 @@ function UserCard(props) {
   }
 
   const handleUserFollow = event => {
-    console.log(starState)
+    // console.log(starState)
     setStarState({stared: ! starState.stared})
     // TODO: send an api request saving the follow/unfollow
   }
@@ -40,8 +43,6 @@ function UserCard(props) {
 
   const navigate = useNavigate()
 
-  console.log(author)
-
   // RENDER
 
   return (
@@ -53,11 +54,11 @@ function UserCard(props) {
         <CardHeader 
           avatar = {
             <Avatar sx={{ bgcolor: 'secondary.main' }} aria-label="user">
-              {author.level}
+              {"U"/*authorAccountInfo.level*/}
             </Avatar>
           }
-          title={author.accountInfo.name + " " + author.accountInfo.surname}
-          subheader={createdAt}
+          title={authorAccountInfo.username}
+          subheader={creationDate}
           action={
             <IconButton onClick={handleOpenUserMenu} aria-label="settings">
               <MoreVertIcon />
@@ -81,25 +82,25 @@ function UserCard(props) {
           open={Boolean(anchorElUser)}
           onClose={handleCloseUserMenu}
         >
-          <MenuItem key='See Profile' onClick={() => {navigate("/user/" + author.user_id)}}>
+          <MenuItem key='See Profile' onClick={() => {navigate("/user/" + authorAccountInfo.id)}}>
             <Typography textAlign="center">See Profile</Typography>
           </MenuItem>          
         </Menu>
 
-        {body && // if commentData is provided as parameter, render it.
+        {text && // if commentData is provided as parameter, render it.
           <CardContent>
             <Typography variant="body2" color="text.secondary">
-              {body}
+              {text}
             </Typography>
           </CardContent>
         }
 
         {token && // if logged_in_user, render below 
           <CardActions disableSpacing>
-            <IconButton onClick={body ? handleCommentLike : handleUserFollow} aria-label="add to favorites">
+            <IconButton onClick={text ? handleCommentLike : handleUserFollow} aria-label="add to favorites">
               {starState.stared ? <StarIcon /> : <StarOutlineIcon />}
             </IconButton>
-            {body ? "Like Comment" : "Follow User"}
+            {text ? "Like Comment" : "Follow User"}
           </CardActions>
         }
       </Card>

--- a/frontend/src/pages/ArtItemPage/ArtItemPage.js
+++ b/frontend/src/pages/ArtItemPage/ArtItemPage.js
@@ -49,27 +49,21 @@ function ArtItemPage() {
   return (
     <GenericCardLayout maxWidth={1000}>
       <Typography variant="h4" sx={{padding:2}}>
-        {artitem.artItemInfo.name}
+        {artitem.name}
       </Typography>
     
       <Grid container spacing={2}>
         <Grid item xs={12} sm={8}>
-          <ImageComponent imageId={artitem.artItemInfo.imageId}/>          
+          <ImageComponent imageId={artitem.imageId}/>          
         </ Grid>
         <Grid item xs={12} sm={4}>
-          {/*
-
-          // TODO: endpoint doesn't save owner, no art item has artist
-          // add owner back once issue is fixed.
-
           <Typography variant="h5">Owner:</Typography>
-          <UserCard author={artitem.owner}/>
-          */}
+          <UserCard data={artitem.creatorAccountInfo}/>
           
           <Typography variant="h5">Description:</Typography>
-          <Typography variant="body1">{artitem.artItemInfo.description}</Typography>
+          <Typography variant="body1">{artitem.description}</Typography>
 
-          {artitem.lastPrice && // if auction_id exists, render block below
+          {artitem.onAuction && // if auction_id exists, render block below
           // TODO render auction properly
             <div>
               <Typography variant="h5">Auction Price:</Typography>

--- a/frontend/src/pages/ArtItemPage/CreateArtItemPage.js
+++ b/frontend/src/pages/ArtItemPage/CreateArtItemPage.js
@@ -14,8 +14,8 @@ function CreateArtItemForm(props) {
       {
         name: "",
         description: "",
-        category: "",
-        labels: ""
+        category: [],
+        labels: []
       }
     );
     const [selectedImage, setSelectedImage] = React.useState(null);
@@ -26,8 +26,8 @@ function CreateArtItemForm(props) {
         artItemInfo: {
           name: formInput.name,
           description: formInput.description,
-          category: formInput.category,
-          labels: formInput.labels,
+          category: [formInput.category],
+          labels: [formInput.labels],
           imageId: imageId
         },
         lastPrice: 0

--- a/frontend/src/pages/DiscussionPage/CreateDiscussionPostPage.js
+++ b/frontend/src/pages/DiscussionPage/CreateDiscussionPostPage.js
@@ -1,0 +1,98 @@
+
+import React from 'react'
+import {useNavigate} from 'react-router-dom';
+import { useAuth } from "../../auth/useAuth";
+import { TextField, Typography, Stack } from "@mui/material";
+import GenericCardLayout from "../../layouts/GenericCardLayout";
+import LoadingButton from '../../components/LoadingButton';
+
+function CreateDiscussionPostForm(props) {
+  const [formInput, setFormInput] = React.useReducer(
+    (state, newState) => ({ ...state, ...newState }),
+    {
+      title: "",
+      textBody: "",
+    }
+  );
+  const handleInput = event => {
+    const name = event.target.name;
+    const newValue = event.target.value;
+    setFormInput({ [name]: newValue });
+  };
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const navigate = useNavigate()
+  const { token } = useAuth()
+  const handleSubmit = event => {
+    event.preventDefault();
+    setIsLoading(true)
+    
+    fetch("/api/discussionPost", {
+      method: "POST",
+      body: JSON.stringify(formInput),
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer " + token
+      },
+    })
+      .then(response => response.json())
+      .then(data => navigate("/discussionPost/" + data.id))
+  };
+  
+  return (
+    <>
+      <Typography variant="h5" component="h3">
+        New Discussion Post
+      </Typography>
+
+      <form onSubmit={handleSubmit}>
+        <Stack>
+          <TextField
+            required
+            id="outlined-required"
+            label="Post Title"
+            name="title"
+            defaultValue={formInput.title}
+            onChange={handleInput}
+            sx = {{marginY: 1}}
+          />
+          <TextField
+            required
+            multiline
+            minRows={2}
+            maxRows={6}
+            id="outlined-required"
+            label="Your Post"
+            name="textBody"
+            defaultValue={formInput.textBody}
+            onChange={handleInput}
+            sx = {{marginY: 1}}
+          />
+
+          <br/>
+
+          <LoadingButton
+            loading={isLoading}
+            label="Create Discussion Post"
+            loadingText="Creating Discussion Post"
+            type="submit"
+            variant="contained"
+            color="primary"
+          />
+        </Stack>
+      </form>
+    </>
+  )
+}
+
+function CreateDiscussionPostPage() {
+  return (
+    <GenericCardLayout maxWidth={1000}>
+      <div sx={{marginX: 50}}>
+        <CreateDiscussionPostForm/>
+      </div>
+    </GenericCardLayout>
+  )
+}
+  
+export default CreateDiscussionPostPage

--- a/frontend/src/pages/DiscussionPage/DiscussionPostPage.js
+++ b/frontend/src/pages/DiscussionPage/DiscussionPostPage.js
@@ -1,0 +1,76 @@
+import React, {useEffect, useState} from 'react'
+import { Typography, Stack } from "@mui/material";
+import { useAuth } from "../../auth/useAuth"
+import {useParams} from "react-router-dom";
+import UserCard from "../../common/UserCard"
+import GenericCardLayout from '../../layouts/GenericCardLayout';
+import CommentSection from '../../common/CommentSection';
+
+function DiscussionPostPage() {
+
+  let { id } = useParams();
+  const [state, setState] = useState({
+    error: null,
+    isLoaded: false,
+    discussionPost: [] 
+  })
+
+  // TODO: remove token
+  const { token } = useAuth()
+  useEffect(() => {
+
+    const fetchArgs = {
+      method: "GET",  
+    }
+
+    if (token) fetchArgs.headers = {Authorization: "Bearer " + token}
+    fetch('/api/discussionPost/' + id, fetchArgs)
+      .then((response) => response.json())
+      .then((data) => {
+        console.log(data)
+        setState({error: null, isLoaded: true, discussionPost: data})
+      },
+        error => {
+          setState({error: error})
+        }
+      )
+  }, [id, token])
+
+  const {error, isLoaded, artitem} = state
+
+  if (error) {
+    return <div>Error: {error.message}</div>
+  } else if (!isLoaded) {
+    return <div>Loading...</div>
+  } else {
+    return (
+      <GenericCardLayout maxWidth={1000}>
+
+        <Stack>
+          <Typography variant="h4" sx={{padding:2}}>
+            {state.discussionPost.title}
+          </Typography>
+          <br/>
+
+          <Typography variant="body1">
+            {state.discussionPost.textBody}
+          </Typography>
+
+          <UserCard data={state.discussionPost.creatorAccountInfo} />
+
+          <CommentSection
+            contentId={id}
+            commentList={state.discussionPost.commentList}
+          />
+
+        </Stack>
+
+      </GenericCardLayout>
+    )
+  }
+}
+
+
+
+
+export default DiscussionPostPage

--- a/frontend/src/pages/EventPage/CreatePhysicalEventPage.js
+++ b/frontend/src/pages/EventPage/CreatePhysicalEventPage.js
@@ -15,9 +15,9 @@ function CreatePhysicalEventForm() {
     {
       title: "",
       description: "",
-      category: "",
+      category: [],
       eventPrice: "",
-      labels: "",
+      labels: [],
       rules: "",
       address: ""
     }
@@ -32,9 +32,9 @@ function CreatePhysicalEventForm() {
       eventInfo: {
         title: formInput.title,
         description: formInput.description,
-        category: formInput.category,
+        category: [formInput.category],
         eventPrice: formInput.eventPrice,
-        labels: formInput.labels,
+        labels: [formInput.labels],
         posterId: posterId
       },
       location: {


### PR DESCRIPTION
With this PR, I am doing the following:
- Backend: Adding account info field to the discussion post DTO
- Frontend: fixing some issues in our pages that arised from updates in endpoints
- Frontend: Adding Discussion Pages

## Backend: Discussion Post DTO

The account info didn't exist in the response. I added it to the response and tested it on the frontend. I think it works. I added @sabrimete as a reviewer.

## Frontend: Discussion Post

### Create page

![image](https://user-images.githubusercontent.com/57228345/205034361-c0da4cdb-031f-4e02-b2ef-d6fce2b3c1d6.png)

### View Page

![image](https://user-images.githubusercontent.com/57228345/205034434-45bb7c32-2b3f-4868-a44d-3257e89e0d99.png)

Styling looks terrible but I would like to merge this PR and handle the styling later.
