### PR TITLE
fixed art item category field in homepage

### DIFF
--- a/android/lib/models/post_model.dart
+++ b/android/lib/models/post_model.dart
@@ -138,19 +138,20 @@ class Post {
             ],
           ),
           const SizedBox(height: 10.0),
-          Row(
-            children: [
-              Icon(
-                Icons.category,
-                color: Colors.grey[600],
-                size: 12.0,
-              ),
-              const SizedBox(width: 5.0),
-              Text(
-                artItem.artItemInfo.category.toString(),
-              ),
-            ],
-          ),
+          if (artItem.artItemInfo.category != null)
+            Row(
+              children: [
+                Icon(
+                  Icons.category,
+                  color: Colors.grey[600],
+                  size: 12.0,
+                ),
+                const SizedBox(width: 5.0),
+                Text(
+                  artItem.artItemInfo.category!.join(", "),
+                ),
+              ],
+            ),
         ],
       );
     }


### PR DESCRIPTION
I have fixed category field of art items in homepage after @canatakan's feedback to [this pull request](https://github.com/bounswe/bounswe2022group7/pull/485).

Now categories look like this:

![Screenshot (128)](https://user-images.githubusercontent.com/59166549/205477640-1c7f86a2-6afc-4350-9f0a-82f72d48a1a8.png)
