### PR TITLE
Recommendations for General and User Specific

### DIFF
--- a/backend/src/main/kotlin/com/group7/artshare/DTO/ArtItemDTO.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/DTO/ArtItemDTO.kt
@@ -2,11 +2,12 @@ package com.group7.artshare.DTO
 
 import com.group7.artshare.entity.AccountInfo
 import com.group7.artshare.entity.Auction
+import com.group7.artshare.entity.RegisteredUser
 import lombok.Data
 import java.util.*
 
 @Data
-class ArtItemDTO {
+class ArtItemDTO : Comparable<ArtItemDTO> {
     var id : Long? = null
     var name : String? = null
     var description : String? = null
@@ -23,5 +24,10 @@ class ArtItemDTO {
     var lastPrice : Double? = null
     var commentList: MutableList<CommentDTO> = mutableListOf()
 //    var bookMarkedByIds : MutableList<Long> = mutableListOf()
+
+    override fun compareTo(other: ArtItemDTO): Int {
+        //TODO update this to number of likes
+        return other.commentList.size - this.commentList.size
+    }
 
 }

--- a/backend/src/main/kotlin/com/group7/artshare/DTO/EventDTO.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/DTO/EventDTO.kt
@@ -1,12 +1,11 @@
 package com.group7.artshare.DTO
 
-import com.group7.artshare.entity.AccountInfo
-import com.group7.artshare.entity.EventInfo
+import com.group7.artshare.entity.*
 import lombok.Data
 import java.util.*
 
 @Data
-open class EventDTO {
+open class EventDTO : Comparable<EventDTO> {
     var id : Long? = null
     var type: String? = null
     var creatorId: Long? = null
@@ -15,4 +14,9 @@ open class EventDTO {
     var commentList: MutableList<CommentDTO> = mutableListOf()
     var eventInfo: EventInfo? = null
     var participantUsernames : MutableList<String> = mutableListOf()
+
+    override fun compareTo(other: EventDTO): Int {
+        return other.participantUsernames.size - this.participantUsernames.size
+    }
+
 }

--- a/backend/src/main/kotlin/com/group7/artshare/controller/Homepage.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/controller/Homepage.kt
@@ -6,19 +6,21 @@ import com.group7.artshare.entity.*
 import com.group7.artshare.repository.ArtItemRepository
 import com.group7.artshare.repository.OnlineGalleryRepository
 import com.group7.artshare.repository.PhysicalExhibitionRepository
+import com.group7.artshare.service.HomepageService
 import com.group7.artshare.service.JwtService
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
 import java.util.*
-import java.util.stream.Collectors
 
 
 @RestController
 @CrossOrigin(origins = ["*"], allowedHeaders = ["*"])
 @RequestMapping("homepage")
-class Homepage(private val jwtService: JwtService) {
+class Homepage(
+    private val jwtService: JwtService, private val homepageService: HomepageService
+) {
 
     @Autowired
     lateinit var artItemRepository: ArtItemRepository
@@ -32,16 +34,15 @@ class Homepage(private val jwtService: JwtService) {
     @GetMapping("event")
     fun getRecommendedEvents(
         @RequestHeader(
-            value = "Authorization",
-            required = false
+            value = "Authorization", required = false
         ) authorizationHeader: String?
     ): List<EventDTO> {
         try {
             authorizationHeader?.let {
                 val user =
                     jwtService.getUserFromAuthorizationHeader(authorizationHeader) ?: throw Exception("Invalid token")
-                return getRecommendedEventsForUser(user)
-            } ?: return getRecommendedEventsGeneric()
+                return homepageService.getRecommendedEventsForUser(user)
+            } ?: return homepageService.getRecommendedEventsGeneric()
         } catch (e: Exception) {
             if (e.message == "Invalid token") {
                 throw ResponseStatusException(HttpStatus.UNAUTHORIZED, e.message)
@@ -54,16 +55,15 @@ class Homepage(private val jwtService: JwtService) {
     @GetMapping("artItem")
     fun getRecommendedArtItems(
         @RequestHeader(
-            value = "Authorization",
-            required = false
+            value = "Authorization", required = false
         ) authorizationHeader: String?
     ): List<ArtItemDTO> {
         try {
             authorizationHeader?.let {
                 val user =
                     jwtService.getUserFromAuthorizationHeader(authorizationHeader) ?: throw Exception("Invalid token")
-                return getRecommendedArtItemsForUser(user)
-            } ?: return getRecommendedArtItemsGeneric()
+                return homepageService.getRecommendedArtItemsForUser(user)
+            } ?: return homepageService.getRecommendedArtItemsGeneric()
         } catch (e: Exception) {
             if (e.message == "Invalid token") {
                 throw ResponseStatusException(HttpStatus.UNAUTHORIZED, e.message)
@@ -72,26 +72,5 @@ class Homepage(private val jwtService: JwtService) {
             }
         }
     }
-
-    fun getRecommendedEventsGeneric(): List<EventDTO> {
-        return (physicalExhibitionRepository.findAll().map { it.mapToDTO() } + onlineGalleryRepository.findAll().map { it.mapToDTO() }).sorted()
-    }
-
-    fun getRecommendedEventsForUser(user: RegisteredUser): List<EventDTO> {
-        //        #TODO: implement this
-        val list = physicalExhibitionRepository.findAll().map { it.mapToDTO() } + onlineGalleryRepository.findAll().map { it.mapToDTO() }
-
-        return list.sorted()
-    }
-
-    fun getRecommendedArtItemsGeneric(): List<ArtItemDTO> {
-        return (artItemRepository.findAll().stream().map(ArtItem::mapToDTO).collect(Collectors.toList())).sorted()
-    }
-
-    fun getRecommendedArtItemsForUser(user: RegisteredUser): List<ArtItemDTO> {
-        //        #TODO: implement this
-        val list = artItemRepository.findAll().stream().map(ArtItem::mapToDTO).collect(Collectors.toList())
-        return list.sorted()
-}
 
 }

--- a/backend/src/main/kotlin/com/group7/artshare/controller/Homepage.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/controller/Homepage.kt
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
+import java.util.*
 import java.util.stream.Collectors
 
 
@@ -73,21 +74,24 @@ class Homepage(private val jwtService: JwtService) {
     }
 
     fun getRecommendedEventsGeneric(): List<EventDTO> {
-        return physicalExhibitionRepository.findAll().map { it.mapToDTO() } + onlineGalleryRepository.findAll().map { it.mapToDTO() }
+        return (physicalExhibitionRepository.findAll().map { it.mapToDTO() } + onlineGalleryRepository.findAll().map { it.mapToDTO() }).sorted()
     }
 
     fun getRecommendedEventsForUser(user: RegisteredUser): List<EventDTO> {
         //        #TODO: implement this
-        return physicalExhibitionRepository.findAll().map { it.mapToDTO() } + onlineGalleryRepository.findAll().map { it.mapToDTO() }
+        val list = physicalExhibitionRepository.findAll().map { it.mapToDTO() } + onlineGalleryRepository.findAll().map { it.mapToDTO() }
+
+        return list.sorted()
     }
 
     fun getRecommendedArtItemsGeneric(): List<ArtItemDTO> {
-        return artItemRepository.findAll().stream().map(ArtItem::mapToDTO).collect(Collectors.toList())
+        return (artItemRepository.findAll().stream().map(ArtItem::mapToDTO).collect(Collectors.toList())).sorted()
     }
 
     fun getRecommendedArtItemsForUser(user: RegisteredUser): List<ArtItemDTO> {
         //        #TODO: implement this
-        return artItemRepository.findAll().stream().map(ArtItem::mapToDTO).collect(Collectors.toList())
+        val list = artItemRepository.findAll().stream().map(ArtItem::mapToDTO).collect(Collectors.toList())
+        return list.sorted()
 }
 
 }

--- a/backend/src/main/kotlin/com/group7/artshare/controller/HomepageController.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/controller/HomepageController.kt
@@ -18,7 +18,7 @@ import java.util.*
 @RestController
 @CrossOrigin(origins = ["*"], allowedHeaders = ["*"])
 @RequestMapping("homepage")
-class Homepage(
+class HomepageController(
     private val jwtService: JwtService, private val homepageService: HomepageService
 ) {
 

--- a/backend/src/main/kotlin/com/group7/artshare/service/HomepageService.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/service/HomepageService.kt
@@ -22,9 +22,11 @@ class HomepageService(
     }
 
     fun getRecommendedEventsForUser(user: RegisteredUser): List<EventDTO> {
-        //        #TODO: implement this
-        val list = physicalExhibitionRepository.findAll().map { it.mapToDTO() } + onlineGalleryRepository.findAll().map { it.mapToDTO() }
-        return list.sorted()
+        val followingUserIds = user.following.map { it.id }
+        val eventDTOs = physicalExhibitionRepository.findAll().map { it.mapToDTO() } + onlineGalleryRepository.findAll().map { it.mapToDTO() }
+        val followingEventDTOs = eventDTOs.filter {followingUserIds.contains(it.creatorId)}
+        val notFollowingEventDTOs = eventDTOs - followingEventDTOs.toSet()
+        return followingEventDTOs.sorted() + notFollowingEventDTOs.sorted()
     }
 
     fun getRecommendedArtItemsGeneric(): List<ArtItemDTO> {

--- a/backend/src/main/kotlin/com/group7/artshare/service/HomepageService.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/service/HomepageService.kt
@@ -32,8 +32,10 @@ class HomepageService(
     }
 
     fun getRecommendedArtItemsForUser(user: RegisteredUser): List<ArtItemDTO> {
-        //        #TODO: implement this
-        val list = artItemRepository.findAll().stream().map(ArtItem::mapToDTO).collect(Collectors.toList())
-        return list.sorted()
+        val followingUserIds = user.following.map { it.id }
+        val artItemDTOs = artItemRepository.findAll().map { it.mapToDTO() }
+        val followingArtItemDTOs = artItemDTOs.filter {followingUserIds.contains(it.creatorId)}
+        val notFollowingArtItemDTOs = artItemDTOs - followingArtItemDTOs.toSet()
+        return followingArtItemDTOs.sorted() + notFollowingArtItemDTOs.sorted()
     }
 }

--- a/backend/src/main/kotlin/com/group7/artshare/service/HomepageService.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/service/HomepageService.kt
@@ -1,0 +1,39 @@
+package com.group7.artshare.service
+
+import com.group7.artshare.DTO.ArtItemDTO
+import com.group7.artshare.DTO.EventDTO
+import com.group7.artshare.entity.*
+import com.group7.artshare.repository.*
+import com.group7.artshare.request.*
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
+import java.util.stream.Collectors
+
+@Service
+class HomepageService(
+    private val artItemRepository: ArtItemRepository,
+    private val onlineGalleryRepository: OnlineGalleryRepository,
+    private val physicalExhibitionRepository: PhysicalExhibitionRepository
+) {
+
+    fun getRecommendedEventsGeneric(): List<EventDTO> {
+        return (physicalExhibitionRepository.findAll().map { it.mapToDTO() } + onlineGalleryRepository.findAll().map { it.mapToDTO() }).sorted()
+    }
+
+    fun getRecommendedEventsForUser(user: RegisteredUser): List<EventDTO> {
+        //        #TODO: implement this
+        val list = physicalExhibitionRepository.findAll().map { it.mapToDTO() } + onlineGalleryRepository.findAll().map { it.mapToDTO() }
+        return list.sorted()
+    }
+
+    fun getRecommendedArtItemsGeneric(): List<ArtItemDTO> {
+        return (artItemRepository.findAll().stream().map(ArtItem::mapToDTO).collect(Collectors.toList())).sorted()
+    }
+
+    fun getRecommendedArtItemsForUser(user: RegisteredUser): List<ArtItemDTO> {
+        //        #TODO: implement this
+        val list = artItemRepository.findAll().stream().map(ArtItem::mapToDTO).collect(Collectors.toList())
+        return list.sorted()
+    }
+}

--- a/backend/src/test/kotlin/com/group7/artshare/controller/HomepageControllerTest.kt
+++ b/backend/src/test/kotlin/com/group7/artshare/controller/HomepageControllerTest.kt
@@ -1,0 +1,51 @@
+package com.group7.artshare.controller
+
+import com.group7.artshare.entity.*
+import com.group7.artshare.service.HomepageService
+import com.group7.artshare.service.JwtService
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+import java.util.*
+
+
+@ExtendWith(MockitoExtension::class)
+internal class HomepageControllerTest {
+
+    @InjectMocks
+    lateinit var homepageController: HomepageController
+
+    @Mock
+    lateinit var homepageService: HomepageService
+
+    @Mock
+    lateinit var jwtService: JwtService
+
+    @Test
+    fun successfullyReturnsArtItemList() {
+        val mockArtItem1 = ArtItem()
+        val mockArtItemInfo1 = ArtItemInfo()
+        mockArtItem1.artItemInfo = mockArtItemInfo1
+        val mockArtItem2 = ArtItem()
+        val mockArtItemInfo2 = ArtItemInfo()
+        mockArtItem2.artItemInfo = mockArtItemInfo2
+        val mockArtItemDTOList = listOf(mockArtItem1.mapToDTO(), mockArtItem2.mapToDTO())
+        `when`(homepageService.getRecommendedArtItemsGeneric()).thenReturn(mockArtItemDTOList)
+        val response = homepageController.getRecommendedArtItems(null)
+        assertEquals(response, mockArtItemDTOList)
+    }
+
+    @Test
+    fun successfullyReturnsEventList() {
+        val mockEvent1 = PhysicalExhibition()
+        val mockEvent2 = OnlineGallery()
+        val mockEventDTOList = listOf(mockEvent1.mapToDTO(), mockEvent2.mapToDTO())
+        `when`(homepageService.getRecommendedEventsGeneric()).thenReturn(mockEventDTOList)
+        val response = homepageController.getRecommendedEvents(null)
+        assertEquals(response, mockEventDTOList)
+    }
+}


### PR DESCRIPTION
Homepage contains all Art Items and Events. We need a recommendation algorithm to modify this page according to satisfy the user expectations.

- Algorithm is attached below:

If the user is not registered, we are returning a default list, which is based on the popularity of this items.

If the user is registered, this user's following artists (if any) have priority on the homepage. We are returning these artists' items first (among them popularity is used as sorting again), and then the other items.

- Popularity

For events, number of participants is the indicator of the popularity of an event

For art items, number of likes is the indicator of the popularity of an art item

- Additionsl Notes:

I used comment number of an art item for sorting for now, hence we have not implemented the like endpoints and field yet. I left a TODO in that field.


