### PR TITLE
Dev/backend/event participation

### DIFF
--- a/backend/src/main/kotlin/com/group7/artshare/controller/EventController.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/controller/EventController.kt
@@ -106,4 +106,23 @@ class EventController(
             }
         }
     }
+
+    @PostMapping("participate/{id}")
+    fun participateAnEvent(
+        @PathVariable("id") id: Long, @RequestHeader(
+            value = "Authorization", required = true
+        ) authorizationHeader: String
+    ): EventDTO {
+        try {
+            val user =
+                jwtService.getUserFromAuthorizationHeader(authorizationHeader) ?: throw Exception("Invalid token")
+            return eventService.participateAnEvent(id, user).mapToDTO()
+        } catch (e: Exception) {
+            if (e.message == "Invalid token") {
+                throw ResponseStatusException(HttpStatus.UNAUTHORIZED, e.message)
+            } else {
+                throw ResponseStatusException(HttpStatus.BAD_REQUEST, e.message)
+            }
+        }
+    }
 }

--- a/backend/src/main/kotlin/com/group7/artshare/entity/Event.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/entity/Event.kt
@@ -44,8 +44,8 @@ abstract class Event{
     @ManyToMany(cascade = [CascadeType.PERSIST, CascadeType.MERGE])
     @JoinTable(
         name = "event_participants",
-        joinColumns = [JoinColumn(name = "attending_user_id")],
-        inverseJoinColumns = [JoinColumn(name = "physical_exhibition_id")]
+        joinColumns = [JoinColumn(name = "event_id")],
+        inverseJoinColumns = [JoinColumn(name = "attending_user_id")]
     )
     @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator::class, property = "id")
     var participants: MutableSet<RegisteredUser> = mutableSetOf()

--- a/backend/src/main/kotlin/com/group7/artshare/service/EventService.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/service/EventService.kt
@@ -80,4 +80,24 @@ class EventService(
             throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "Regular Users cannot delete events")
         }
     }
+
+    fun participateAnEvent(
+        id: Long, user: RegisteredUser
+    ) : Event {
+        val event : Event = physicalExhibitionRepository.findByIdOrNull(id) ?: onlineGalleryRepository.findByIdOrNull(id) ?: throw ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "There is no event in the database with corresponding id"
+        )
+        if(event.participants.contains(user)){
+            event.participants.remove(user)
+            user.allEvents.remove(event)
+        }
+        else{
+            event.participants.add(user)
+            user.allEvents.add(event)
+        }
+        physicalExhibitionRepository.flush()
+        onlineGalleryRepository.flush()
+        return event
+
+    }
 }

--- a/backend/src/test/kotlin/com/group7/artshare/controller/EventControllerTest.kt
+++ b/backend/src/test/kotlin/com/group7/artshare/controller/EventControllerTest.kt
@@ -1,0 +1,57 @@
+package com.group7.artshare.controller
+
+import com.group7.artshare.entity.*
+import com.group7.artshare.service.EventService
+import com.group7.artshare.service.JwtService
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+
+@ExtendWith(MockitoExtension::class)
+internal class EventControllerTest {
+
+    @InjectMocks
+    lateinit var eventController: EventController
+
+    @Mock
+    lateinit var eventService: EventService
+
+    @Mock
+    lateinit var jwtService: JwtService
+
+    @Test
+    fun participateAnEvent() {
+        val authorizationHeader = "Bearer token"
+        val user = RegisteredUser(AccountInfo("email","username", "password"),setOf(Authority("ARTIST")))
+        whenever(jwtService.getUserFromAuthorizationHeader(authorizationHeader)).thenReturn(user)
+        val event = PhysicalExhibition()
+        Mockito.`when`(eventService.participateAnEvent(event.id,user)).then {
+            event.participants.add(user)
+            event
+        }
+        val result = eventController.participateAnEvent(event.id,authorizationHeader)
+        assertEquals(1, result.participantUsernames.size)
+        assertEquals(user.username, result.participantUsernames[0])
+    }
+
+    @Test
+    fun unparticipateAnEvent() {
+        val authorizationHeader = "Bearer token"
+        val user = RegisteredUser(AccountInfo("email","username", "password"),setOf(Authority("ARTIST")))
+        whenever(jwtService.getUserFromAuthorizationHeader(authorizationHeader)).thenReturn(user)
+        val event = PhysicalExhibition()
+        event.participants.add(user)
+        Mockito.`when`(eventService.participateAnEvent(event.id,user)).then {
+            event.participants.remove(user)
+            event
+        }
+        val result = eventController.participateAnEvent(event.id,authorizationHeader)
+        assertEquals(0, result.participantUsernames.size)
+    }
+}


### PR DESCRIPTION
The PR for the issue: https://github.com/bounswe/bounswe2022group7/issues/554

One endpoint call results with this:
<img width="567" alt="Screenshot 2022-12-17 at 17 22 16" src="https://user-images.githubusercontent.com/49492573/208246549-4c270826-23db-4afb-ba64-6f85b19a7780.png">

Second one:
<img width="1027" alt="Screenshot 2022-12-17 at 17 23 32" src="https://user-images.githubusercontent.com/49492573/208246606-44c28bcc-5579-4808-8d97-47663df64559.png">
