### PR TITLE
User Level Update

### DIFF
--- a/backend/src/main/kotlin/com/group7/artshare/service/ArtItemService.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/service/ArtItemService.kt
@@ -26,6 +26,7 @@ class ArtItemService(
         if (user is Artist){
             newArtItem.creator = user
             user.artItems.add(newArtItem)
+            user.level++
         }
         else
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Regular users cannot create physical exhibitions")

--- a/backend/src/main/kotlin/com/group7/artshare/service/DiscussionPostService.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/service/DiscussionPostService.kt
@@ -30,6 +30,7 @@ class DiscussionPostService(
         val newDiscussionPost = DiscussionPost()
         newDiscussionPost.creator = user
         user.writtenDiscussionPosts.add(newDiscussionPost)
+        user.level++
         newDiscussionPost.title = discussionPostRequest.title
         newDiscussionPost.textBody = discussionPostRequest.textBody
         discussionPostRepository.save(newDiscussionPost)

--- a/backend/src/main/kotlin/com/group7/artshare/service/EventService.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/service/EventService.kt
@@ -33,6 +33,7 @@ class EventService(
         if (user is Artist) {
             newPhysicalExhibition.creator = user
             user.hostedEvents.add(newPhysicalExhibition)
+            user.level+=2
         } else throw ResponseStatusException(
             HttpStatus.BAD_REQUEST,
             "Regular users cannot create physical exhibitions"
@@ -57,6 +58,7 @@ class EventService(
         if (user is Artist) {
             newOnlineGallery.creator = user
             user.hostedEvents.add(newOnlineGallery)
+            user.level+=2
         } else throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Regular users cannot create online galleries")
         onlineGalleryRepository.save(newOnlineGallery)
         return newOnlineGallery


### PR DESCRIPTION
User level is updated with some functions of the users. These are:

- Writing discussion post, which increments user level by 1
- Creating art item, which increments user level by 1
- Creating event, which increments user level by 2

Updated user level is included to the profile endpoint.
Default Profile for User:
<img width="311" alt="Screen Shot 2022-12-17 at 17 40 14" src="https://user-images.githubusercontent.com/60310582/208247644-664efed1-1c15-42c8-b002-34d88a7b64fd.png">

Updated Profile after Art Item Creation
<img width="330" alt="Screen Shot 2022-12-17 at 17 40 31" src="https://user-images.githubusercontent.com/60310582/208247674-dd8c6c54-0832-4a3b-9959-768c67f41b88.png">

Updated Profile after Discussion Post Creation
<img width="327" alt="Screen Shot 2022-12-17 at 17 42 14" src="https://user-images.githubusercontent.com/60310582/208247691-6a8595f1-7bcb-47d9-81c3-921060196d63.png">

Updated Profile after Online Gallery Creation
<img width="327" alt="Screen Shot 2022-12-17 at 17 43 16" src="https://user-images.githubusercontent.com/60310582/208247705-dcbe7ecb-4a2c-494f-af6a-5f73a18034f6.png">

Updated Profile after Physical Exhibition Creation
<img width="410" alt="Screen Shot 2022-12-17 at 17 43 47" src="https://user-images.githubusercontent.com/60310582/208247717-7ffd49bc-f858-4656-b7aa-cf194a8be69b.png">

