### PR TITLE
Dev/backend/event collaborators

### DIFF
--- a/backend/src/main/kotlin/com/group7/artshare/DTO/EventDTO.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/DTO/EventDTO.kt
@@ -10,6 +10,7 @@ open class EventDTO : Comparable<EventDTO> {
     var type: String? = null
     var creatorId: Long? = null
     var creatorAccountInfo: AccountInfo? = null
+    var collaboratorAccountInfos : MutableList<AccountInfo> = mutableListOf()
     var creationDate : Date? = null
     var commentList: MutableList<CommentDTO> = mutableListOf()
     var eventInfo: EventInfo? = null

--- a/backend/src/main/kotlin/com/group7/artshare/entity/Event.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/entity/Event.kt
@@ -23,8 +23,8 @@ abstract class Event{
     @JoinColumn(name = "creator")
     @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator::class, property = "id")
     var creator: Artist? = null
-    
-    @ManyToMany(mappedBy = "hostedEvents")
+
+    @ManyToMany(mappedBy = "hostedEvents", fetch = FetchType.EAGER,cascade = [CascadeType.PERSIST, CascadeType.MERGE])
     @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator::class, property = "id")
     var collaborators: MutableSet<Artist> = mutableSetOf()
 

--- a/backend/src/main/kotlin/com/group7/artshare/entity/OnlineGallery.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/entity/OnlineGallery.kt
@@ -30,6 +30,7 @@ class OnlineGallery : Event(){
         dto.type = "online"
         dto.creatorId = this.creator?.id
         dto.creatorAccountInfo = this.creator?.accountInfo
+        dto.collaboratorAccountInfos = this.collaborators.map { it.accountInfo }.toMutableList()
         dto.creationDate = this.creationDate
         dto.commentList = this.commentList.map { it.mapToDTO() }.toMutableList()
         dto.eventInfo = this.eventInfo

--- a/backend/src/main/kotlin/com/group7/artshare/entity/PhysicalExhibition.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/entity/PhysicalExhibition.kt
@@ -26,6 +26,7 @@ class PhysicalExhibition : Event(){
         dto.type = "physical"
         dto.creatorId = this.creator?.id
         dto.creatorAccountInfo = this.creator?.accountInfo
+        dto.collaboratorAccountInfos = this.collaborators.map { it.accountInfo }.toMutableList()
         dto.creationDate = this.creationDate
         dto.commentList = this.commentList.map { it.mapToDTO() }.toMutableList()
         dto.eventInfo = this.eventInfo

--- a/backend/src/main/kotlin/com/group7/artshare/request/OnlineGalleryRequest.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/request/OnlineGalleryRequest.kt
@@ -16,4 +16,6 @@ class OnlineGalleryRequest {
 
     @NotEmpty
     val artItemIds: Set<Long>? = null
+
+    val collaboratorUsernames: MutableList<String> = mutableListOf()
 }

--- a/backend/src/main/kotlin/com/group7/artshare/request/PhysicalExhibitionRequest.kt
+++ b/backend/src/main/kotlin/com/group7/artshare/request/PhysicalExhibitionRequest.kt
@@ -19,4 +19,6 @@ class PhysicalExhibitionRequest {
     val location: Location? = null
 
     val rules: String? = null
+
+    val collaboratorUsernames: MutableList<String> = mutableListOf()
 }


### PR DESCRIPTION
PR for the issue: https://github.com/bounswe/bounswe2022group7/issues/573 

create physical exhibition and online gallery endpoints require collaboratorUsernames field as a string list.
@CahidArda @canatakan  

Here is an example request and response:
<img width="1026" alt="Screenshot 2022-12-23 at 13 57 49" src="https://user-images.githubusercontent.com/49492573/209324240-dd730611-fe5c-4c36-a93f-a357a9cf5703.png">
