### PR TITLE
Remove tag field from annotations (FE, #580)

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -50,7 +50,12 @@ const theme = createTheme({
 
 function App() {
 
-  const r = new Recogito({ content: document.getElementById("root") });
+  const r = new Recogito({
+    content: document.getElementById("root"),
+    widgets: [
+      "COMMENT"
+    ]
+  });
 
   return (
     <div>

--- a/frontend/src/components/ImageComponent.js
+++ b/frontend/src/components/ImageComponent.js
@@ -24,7 +24,10 @@ function ImageComponent({ imageId, imageStyle }) {
 
           if (imgEl.current) {
             annotorious = new Annotorious({
-              image: imgEl.current
+              image: imgEl.current,
+              widgets: [
+                "COMMENT"
+              ]
             })
 
             annotorious.loadAnnotations(`/annotations/${imageId}`)

--- a/frontend/src/components/ImageComponent.js
+++ b/frontend/src/components/ImageComponent.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useRef } from 'react'
 import PropTypes from 'prop-types';
 import { Annotorious } from '@recogito/annotorious';
 import '@recogito/annotorious/dist/annotorious.min.css';
-
+import "../styles/AnnotationEditor.css"
 
 function ImageComponent({ imageId, imageStyle }) {
   const imgEl = useRef(null)

--- a/frontend/src/styles/AnnotationEditor.css
+++ b/frontend/src/styles/AnnotationEditor.css
@@ -1,0 +1,3 @@
+.r6o-widget.comment.editable:not(:first-child) {
+    display: none;
+}


### PR DESCRIPTION
I have removed the tag field from the annotation editors. I have also tried to fix the text annotation initialization in AnnotatableText.js file but I was unable. I think we can merge the editor update but handle the text annotation issue somewhere else.

Closes #580.