### PR TITLE
[Frontend] Delete and Interaction Functionality for Content Pages

### DIFF
--- a/frontend/src/components/ArtItemPreview.js
+++ b/frontend/src/components/ArtItemPreview.js
@@ -11,9 +11,7 @@ import ThumbUpAltIcon from '@mui/icons-material/ThumbUpAlt';
 
 const ImageDisplay = React.lazy(() => import('./ImageDisplay'));
 
-
-export default function ArtItemPreview(props) {
-
+function ArtItemLike(props) {
     const [likeStatus, setLikeStatus] = React.useState(false);
     const [likeCount, setLikeCount] = React.useState(props.content.likeCount || 0);
 
@@ -52,6 +50,18 @@ export default function ArtItemPreview(props) {
     }
 
     return (
+        <Stack spacing={2} direction="row" justifyContent="space-between" alignItems="center" sx={{ mt: 2, width: '100%', color: 'grey' }}>
+            <Button color={likeStatus ? 'secondary' : 'inherit'} disabled={token ? false : true} onClick={handleLike} sx={{fontWeight: 600}} startIcon={likeStatus ? <ThumbUpAltIcon /> : <ThumbUpOffAltIcon />}>{likeStatus ? "liked | " + likeCount : "like | " + likeCount}</Button>
+            <Typography variant="body1" sx={{ fontSize: 14, fontWeight: 600, color: 'gray'}}>{props.content.commentCount + ' comments'}</Typography>
+        </Stack>
+    )
+
+}
+
+function ArtItemPreview(props) {
+
+    
+    return (
         <Stack sx={{ width: '100%' }}>
             <Link to={"/" + props.content.type + "/" + props.content.id} style={{ width: '100%', textDecoration: 'none', color: "black" }}>
                 <Typography variant="title" gutterBottom sx={{ fontWeight: 700, fontSize: 18 }}>
@@ -65,11 +75,10 @@ export default function ArtItemPreview(props) {
                 </Suspense>
             </Link>
 
-            <Stack spacing={2} direction="row" justifyContent="space-between" alignItems="center" sx={{ mt: 2, width: '100%', color: 'grey' }}>
-                <Button color={likeStatus ? 'secondary' : 'inherit'} disabled={token ? false : true} onClick={handleLike} sx={{fontWeight: 600}} startIcon={likeStatus ? <ThumbUpAltIcon /> : <ThumbUpOffAltIcon />}>{likeStatus ? "liked | " + likeCount : "like | " + likeCount}</Button>
-                <Typography variant="body1" sx={{ fontSize: 14, fontWeight: 600, color: 'gray'}}>{props.content.commentCount + ' comments'}</Typography>
-            </Stack>
+            <ArtItemLike content={props.content}/>
         </Stack>
     );
 
 }
+
+export {ArtItemLike, ArtItemPreview}

--- a/frontend/src/components/DiscussionPostPreview.js
+++ b/frontend/src/components/DiscussionPostPreview.js
@@ -15,7 +15,7 @@ import ThumbDownAltIcon from '@mui/icons-material/ThumbDownAlt';
 import ThumbDownOffAltIcon from '@mui/icons-material/ThumbDownOffAlt';
 
 
-export default function DiscussionPostPreview(props) {
+function DiscussionPostVote(props) {
 
     const [likeStatus, setLikeStatus] = React.useState(props.content.voteStatus || 0);
     const [likeCount, setLikeCount] = React.useState(props.content.voteCount || 0);
@@ -91,6 +91,24 @@ export default function DiscussionPostPreview(props) {
     }
 
     return (
+        <Stack spacing={2} direction="row" justifyContent="space-between" alignItems="center" sx={{ mt: 2, width: '100%' }}>
+            {token && <Box>
+                <IconButton onClick={handleUpvote} sx={{ display: 'inline' }} variant="outlined">
+                    {likeStatus === 1 ? <ThumbUpAlt color='secondary' /> : <ThumbUpOffAlt />}
+                </IconButton>
+                <Typography variant="body1" sx={{ display: 'inline', fontWeight: 600, color: 'gray', fontSize: 14 }}>{likeCount}</Typography>
+                <IconButton onClick={handleDownvote} sx={{ display: 'inline', color: likeStatus === 1 ? 'primary' : 'grey' }} variant="outlined">
+                    {likeStatus === -1 ? <ThumbDownAltIcon size="small" color='secondary' /> : <ThumbDownOffAltIcon size="small" />}
+                </IconButton>
+            </Box>}
+            <Typography variant="body1" sx={{ fontSize: 14, fontWeight: 600, color: 'gray' }}>{props.content.commentCount + " comments"}</Typography>
+        </Stack>
+    )
+}
+
+function DiscussionPostPreview(props) {    
+
+    return (
         <Stack sx={{ width: '100%' }}>
             <Link to={"/discussionPost/" + props.content.id} style={{ width: '100%', textDecoration: 'none', color: "black" }}>
                 <Box position="relative" width='100%'>
@@ -106,19 +124,9 @@ export default function DiscussionPostPreview(props) {
                 </Box>
             </Link>
 
-            <Stack spacing={2} direction="row" justifyContent="space-between" alignItems="center" sx={{ mt: 2, width: '100%' }}>
-                {token && <Box>
-                    <IconButton onClick={handleUpvote} sx={{ display: 'inline' }} variant="outlined">
-                        {likeStatus === 1 ? <ThumbUpAlt color='secondary' /> : <ThumbUpOffAlt />}
-                    </IconButton>
-                    <Typography variant="body1" sx={{ display: 'inline', fontWeight: 600, color: 'gray', fontSize: 14 }}>{likeCount}</Typography>
-                    <IconButton onClick={handleDownvote} sx={{ display: 'inline', color: likeStatus === 1 ? 'primary' : 'grey' }} variant="outlined">
-                        {likeStatus === -1 ? <ThumbDownAltIcon size="small" color='secondary' /> : <ThumbDownOffAltIcon size="small" />}
-                    </IconButton>
-                </Box>}
-                <Typography variant="body1" sx={{ fontSize: 14, fontWeight: 600, color: 'gray' }}>{props.content.commentCount + " comments"}</Typography>
-            </Stack>
+            <DiscussionPostVote content={props.content}/>
         </Stack>
     );
-
 }
+
+export {DiscussionPostVote, DiscussionPostPreview}

--- a/frontend/src/components/EventPreview.js
+++ b/frontend/src/components/EventPreview.js
@@ -9,8 +9,7 @@ import { Link } from 'react-router-dom';
 const ImageDisplay = React.lazy(() => import('./ImageDisplay'));
 
 
-export default function EventPreview(props) {
-
+function EventParticipate(props) {
     const [participantStatus, setParticipantStatus] = React.useState("a");
     const [participantCount, setParticipantCount] = React.useState(props.content.participantCount || 0);
 
@@ -42,7 +41,17 @@ export default function EventPreview(props) {
             .catch(error => props.onResponse("error", error));
     }
 
+    return (
+        <Stack spacing={2} direction="row" justifyContent="space-between" alignItems="center" sx={{ mt: 2, width: '100%', color: 'grey' }}>
+            <Typography variant="body1" sx={{ fontSize: 14, fontWeight: 600, color: 'gray' }}>{participantCount + " people participating"}</Typography>
+            {token && <Button color={participantStatus ? 'secondary' : 'inherit'} onClick={handleParticipate} sx={{ fontWeight: 600 }} variant="outlined">
+                {participantStatus ? "Participating" : "Participate"}
+            </Button>}
+        </Stack>
+    )
+}
 
+function EventPreview(props) {
 
     return (
         <Stack sx={{ width: '100%' }}>
@@ -60,13 +69,9 @@ export default function EventPreview(props) {
                 }
             </Link>
 
-            <Stack spacing={2} direction="row" justifyContent="space-between" alignItems="center" sx={{ mt: 2, width: '100%', color: 'grey' }}>
-                <Typography variant="body1" sx={{ fontSize: 14, fontWeight: 600, color: 'gray' }}>{participantCount + " people participating"}</Typography>
-                {token && <Button color={participantStatus ? 'secondary' : 'inherit'} onClick={handleParticipate} sx={{ fontWeight: 600 }} variant="outlined">
-                    {participantStatus ? "Participating" : "Participate"}
-                </Button>}
-            </Stack>
+            <EventParticipate content={props.content}/>
         </Stack>
     );
-
 }
+
+export {EventParticipate, EventPreview}

--- a/frontend/src/pages/ArtItemPage/ArtItemPage.js
+++ b/frontend/src/pages/ArtItemPage/ArtItemPage.js
@@ -9,6 +9,7 @@ import IconWithText from "../../components/IconWithText"
 import AnnotatableText from "../../components/AnnotatableText"
 import GenericCardLayout from "../../layouts/GenericCardLayout";
 import AuctionDisplay from "./AuctionDisplay"
+import {ArtItemLike} from '../../components/ArtItemPreview';
 
 import BrushIcon from '@mui/icons-material/Brush';
 import LabelIcon from '@mui/icons-material/Label';
@@ -47,6 +48,13 @@ function ArtItemPage() {
       )
   }, [id, token])
 
+  const artLikeStatus = (id) => {
+    if (userData === null) {
+        return false;
+    }
+    return userData.likedArtItemIds.includes(id);
+  };
+
   const {error, isLoaded, artitem} = state
 
   if (error) {
@@ -67,6 +75,12 @@ function ArtItemPage() {
       </Typography>
 
       <ImageDisplay imageId={artitem.imageId}/>
+      <ArtItemLike content={{
+        liked: artLikeStatus(artitem.id),
+        likeCount: artitem?.likedByUsernames?.length,
+        id: artitem.id,
+        commentCount: artitem?.commentList?.length,
+      }}/>
 
       <Grid container>
         <Grid item xs={12} sm={8}>

--- a/frontend/src/pages/ArtItemPage/ArtItemPage.js
+++ b/frontend/src/pages/ArtItemPage/ArtItemPage.js
@@ -10,6 +10,7 @@ import AnnotatableText from "../../components/AnnotatableText"
 import GenericCardLayout from "../../layouts/GenericCardLayout";
 import AuctionDisplay from "./AuctionDisplay"
 import {ArtItemLike} from '../../components/ArtItemPreview';
+import LoadingButton from "../../components/LoadingButton"
 
 import BrushIcon from '@mui/icons-material/Brush';
 import LabelIcon from '@mui/icons-material/Label';
@@ -125,8 +126,26 @@ function ArtItemPage() {
         contentId={id}
         commentList={artitem.commentList}
       />
+      {artitem.ownerId == userData?.id &&
+        <div>
+          <br/>
+          As the owner user:
+          <br/>
+          <LoadingButton
+            label="Delete Art Item"
+            onClick={() => {
+              fetch("/api/art_item/" + artitem.id, {
+                method: "DELETE",
+                headers: {Authorization: "Bearer " + token}
+              }).then((response) => {window.location.href = "/"})
+            }}
+            type="submit"
+            variant="contained"
+            color="primary"
+          />
+        </div>
+      }
     </GenericCardLayout>
-    
   )}
 }
 

--- a/frontend/src/pages/DiscussionPage/DiscussionPostPage.js
+++ b/frontend/src/pages/DiscussionPage/DiscussionPostPage.js
@@ -5,6 +5,8 @@ import UserCard from "../../common/UserCard"
 import AnnotatableText from "../../components/AnnotatableText"
 import GenericCardLayout from '../../layouts/GenericCardLayout';
 import CommentSection from '../../common/CommentSection';
+import {DiscussionPostVote} from '../../components/DiscussionPostPreview';
+import { useAuth } from "../../auth/useAuth"
 
 function DiscussionPostPage() {
 
@@ -33,6 +35,8 @@ function DiscussionPostPage() {
       )
   }, [id])
 
+  const { userData } = useAuth();
+
   const {error, isLoaded, artitem} = state
 
   if (error) {
@@ -56,7 +60,12 @@ function DiscussionPostPage() {
         <Typography variant="body1">
           <AnnotatableText text={state.discussionPost.textBody}/>
         </Typography>
-
+        <DiscussionPostVote content= {{
+          id: state.discussionPost.id,
+          voteStatus: userData && (state.discussionPost.upVotedUsernames.includes(userData.accountInfo.username) ? 1 : state.discussionPost.downVotedUsernames.includes(userData.accountInfo.username) ? -1 : 0),
+          voteCount: state.discussionPost.upVotedUsernames.length - state.discussionPost.downVotedUsernames.length,
+          commentCount: state.discussionPost.commentList.length,
+        }}/>
         <br/>
 
         <UserCard data={state.discussionPost} />

--- a/frontend/src/pages/EventPage/EventPage.js
+++ b/frontend/src/pages/EventPage/EventPage.js
@@ -12,6 +12,7 @@ import GenericCardLayout from "../../layouts/GenericCardLayout";
 import MapComponent from "../../components/MapComponent"
 import ImageCollection from "./ImageCollection"
 import {EventParticipate} from '../../components/EventPreview';
+import LoadingButton from "../../components/LoadingButton"
 
 import PersonIcon from '@mui/icons-material/Person';
 import DateRangeIcon from '@mui/icons-material/DateRange';
@@ -167,8 +168,8 @@ function EventPage() {
           <Grid item xs={12} sm={8}>
             <MapComponent
               position={{
-                lat:event.location.latitude, 
-                lng:event.location.longitude
+                lat:event?.location?.latitude, 
+                lng:event?.location?.longitude
               }}
               eventTitle={event.eventInfo.title}
             />
@@ -192,6 +193,26 @@ function EventPage() {
         contentId={id}
         commentList={event.commentList}
       />
+
+      {event.creatorId == userData?.id &&
+        <div>
+          <br/>
+          As the owner user:
+          <br/>
+          <LoadingButton
+            label="Delete Event"
+            onClick={() => {
+              fetch("/api/event/" + event.id, {
+                method: "DELETE",
+                headers: {Authorization: "Bearer " + token}
+              }).then((response) => {window.location.href = "/"})
+            }}
+            type="submit"
+            variant="contained"
+            color="primary"
+          />
+        </div>
+      }
     </GenericCardLayout>
     
   )}

--- a/frontend/src/pages/EventPage/EventPage.js
+++ b/frontend/src/pages/EventPage/EventPage.js
@@ -11,6 +11,7 @@ import AnnotatableText from "../../components/AnnotatableText"
 import GenericCardLayout from "../../layouts/GenericCardLayout";
 import MapComponent from "../../components/MapComponent"
 import ImageCollection from "./ImageCollection"
+import {EventParticipate} from '../../components/EventPreview';
 
 import PersonIcon from '@mui/icons-material/Person';
 import DateRangeIcon from '@mui/icons-material/DateRange';
@@ -30,7 +31,7 @@ function EventPage() {
   })
 
   const theme = useTheme();
-  const { token } = useAuth()
+  const { token, userData } = useAuth()
   
   useEffect(() => {
 
@@ -51,6 +52,13 @@ function EventPage() {
   }, [id, token])
 
   const {error, isLoaded, event} = state
+
+  const eventParticipateStatus = (id) => {
+    if (userData === null) {
+        return false;
+    }
+    return userData.participatedEventIds.includes(id);
+  };
 
   if (error) {
     return <div>Error: {error.message}</div>
@@ -75,7 +83,12 @@ function EventPage() {
         {event.eventInfo.title}
       </Typography>
     
-      <ImageDisplay imageId={event.eventInfo.posterId}/>          
+      <ImageDisplay imageId={event.eventInfo.posterId}/>   
+      <EventParticipate content={{
+        participated: eventParticipateStatus(event.id),
+        participantCount: event?.participantUsernames?.length,
+        id: event.id
+      }}/>       
 
       <Grid container spacing={2}>
         <Grid item xs={12} sm={8}>

--- a/frontend/src/pages/HomePage/FeedCard.js
+++ b/frontend/src/pages/HomePage/FeedCard.js
@@ -17,9 +17,9 @@ import { Link } from 'react-router-dom';
 import UserAvatar from "../../components/UserAvatar";
 import CustomizableDropdownMenu from "../../components/CustomizableDropdownMenu";
 import LoadingButton from "../../components/LoadingButton";
-import ArtItemPreview from '../../components/ArtItemPreview';
-import EventPreview from '../../components/EventPreview';
-import DiscussionPostPreview from '../../components/DiscussionPostPreview';
+import {ArtItemPreview} from '../../components/ArtItemPreview';
+import {EventPreview} from '../../components/EventPreview';
+import {DiscussionPostPreview} from '../../components/DiscussionPostPreview';
 
 // TODO: Implement menu items
 let menuContent = [


### PR DESCRIPTION
I have added delete functionality to events and art items #608. This PR contains changes made in #597. We should either wait for that PR to finish or review everything in this PR and merge the changes.

Additionally, I have slightly changed the preview components @erimerkin wrote for the home page. I have split them all into two parts:
- wrapper and the image
- user interaction

Then I used the user interaction part in the corresponding content pages. Following is an example from the art item page:

![image](https://user-images.githubusercontent.com/57228345/209569641-69233c2e-3ef2-4cf9-8f60-80521a84eeab.png)

Closes #608.
