### PR TITLE
[Annotation] Fix for get request 2

### DIFF
--- a/annotations/app.js
+++ b/annotations/app.js
@@ -55,7 +55,7 @@ router.post('/annotations', koaBody(), async ctx => {
     })
     .put('/annotations', koaBody(), async ctx => {
         const result = await annotations.updateOne(
-            { id: { $regex: `^${ctx.params.id}` }},
+            { id: { $regex: `^${ctx.params.id}-` }},
             {
                 $set: {
                     body: ctx.request.body.body
@@ -67,13 +67,13 @@ router.post('/annotations', koaBody(), async ctx => {
 
     })
     .del('/annotations', async ctx => {
-        const result = await annotations.deleteOne({ id: { $regex: `^${ctx.params.id}` } })
+        const result = await annotations.deleteOne({ id: { $regex: `^${ctx.params.id}-` } })
             .catch(err => console.error(err.message))
 
         ctx.body = result.deletedCount
     })
     .get('/annotations/:id', async ctx => {
-        ctx.body = await findOperations({ id: { $regex: `^${ctx.params.id}` } })
+        ctx.body = await findOperations({ id: { $regex: `^${ctx.params.id}-` } })
     })
 
 app.use(router.routes())


### PR DESCRIPTION
This PR fixes the case where annotations with same start like `a16` and `a166` being retrieved in requests for `a16`.